### PR TITLE
security: remove mail api key usage from frontend

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,62 +5,15 @@ import { db } from "../lib/firebase";
 import type { Property, Season, TouristTaxBand, Booking, Role } from "./schemas";
 import { COL } from "./schemas";
 
-const MAIL_API = (import.meta as unknown as { env: Record<string, string | undefined> }).env.VITE_MAIL_API_URL;
-const MAIL_API_KEY = (import.meta as unknown as { env: Record<string, string | undefined> }).env.VITE_MAIL_API_KEY;
-const OWNER_EMAIL = (import.meta as unknown as { env: Record<string, string | undefined> }).env.VITE_OWNER_EMAIL;
-
 async function sendAdminActionMail(
   action: "approved" | "declined" | "cancelled",
   booking: (Booking & { id: string }),
   propertyName?: string
 ): Promise<{ ok: boolean; detail?: string }> {
-  if (!MAIL_API || !MAIL_API_KEY) {
-    console.warn("[mail] skipped – MAIL_API or API_KEY missing");
-    return { ok: false, detail: "mail_api_missing" };
-  }
-  try {
-    const payload = {
-      type: "admin_action",
-      action,
-      bookingId: booking.id,
-      propertyId: booking.propertyId,
-      startDate: booking.startDate,
-      endDate: booking.endDate,
-      adults: booking.adults,
-      children: booking.children,
-      contact: booking.contact,
-      message: booking.message ?? "",
-      status: booking.status,
-      notify: { guest: booking.contact?.email, owner: OWNER_EMAIL },
-      propertyName,
-    };
-    const resp = await fetch(MAIL_API, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Api-Key": MAIL_API_KEY,
-      },
-      body: JSON.stringify(payload),
-    });
-    const text = await resp.text();
-    interface MailApiResponse {
-      ok?: boolean;
-      detail?: string;
-    }
-    let json: MailApiResponse | null = null;
-    try { json = text ? JSON.parse(text) : null; } catch {
-      // ignore JSON parse errors
-    }
-    if (!resp.ok) {
-      const detail = json?.detail ? JSON.stringify(json.detail) : text || String(resp.status);
-      console.warn("[mail] admin action failed:", resp.status, detail);
-      return { ok: false, detail };
-    }
-    return { ok: json?.ok ?? true, detail: json?.detail ? JSON.stringify(json.detail) : undefined };
-  } catch (e) {
-    console.warn("[mail] admin action error:", e);
-    return { ok: false, detail: e instanceof Error ? e.message : "fetch_failed" };
-  }
+  // Mailversand passiert serverseitig über Firestore Trigger (Cloud Functions).
+  // Kein API-Key im Frontend.
+  console.info("[mail] %s handled by server-side trigger (booking=%s, property=%s)", action, booking.id, propertyName ?? booking.propertyId);
+  return { ok: true, detail: "handled_by_server_trigger" };
 }
 
 /** Properties */

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -243,44 +243,9 @@ export default function Booking() {
       });
       console.debug("[booking] submit – createBookingRequest ✓");
 
-      // Nach erfolgreichem Speichern: Mail-Endpoint aufrufen (nicht blockierend für den UX-Flow)
-      try {
-        const mailUrl = import.meta.env.VITE_MAIL_API_URL as string | undefined;
-        const mailKey = import.meta.env.VITE_MAIL_API_KEY as string | undefined;
-        if (mailUrl && mailKey) {
-          const resp = await fetch(mailUrl, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Api-Key": mailKey,
-            },
-            body: JSON.stringify({
-              propertyId: String(propertyId),
-              propertyName,
-              startDate: startISO,
-              endDate: endISO,
-              adults: adultsNum,
-              children: childrenNum,
-              contact: {
-                name: nameClean,
-                email: emailClean,
-                phone: phoneClean,
-                address: { street, zip, city, country },
-              },
-              message: messageClean,
-            }),
-          });
-          console.debug("[booking] mail resp", resp.status);
-          if (!resp.ok) {
-            const errJson = await resp.json().catch(() => ({} as Record<string, unknown>));
-            console.warn("[mail] send failed", resp.status, errJson);
-          }
-        } else {
-          console.info("[mail] skipped – VITE_MAIL_API_URL / VITE_MAIL_API_KEY not set");
-        }
-      } catch (e) {
-        console.warn("[mail] fetch error", e);
-      }
+        // Mailversand läuft serverseitig über Firestore Trigger (Cloud Functions).
+        // Kein API-Key im Frontend.
+        console.debug("[mail] handled by server-side trigger");
 
       flash({ type: "success", text: "Vielen Dank! Deine Anfrage wurde übermittelt. Wir melden uns zeitnah." });
     } catch (err) {


### PR DESCRIPTION
## Summary
Removes client-side mail API key usage from the frontend and switches mail handling to server-side trigger flow.

## What changed
- Removed direct mail API call (with `X-Api-Key`) from `src/pages/Booking.tsx`.
- Removed frontend env key usage from `src/lib/db.ts`:
  - deleted `VITE_MAIL_API_KEY` / `VITE_MAIL_API_URL` key-based request path
  - `sendAdminActionMail(...)` now returns a server-trigger placeholder result and logs intent
- Kept booking UX unchanged (request submission still succeeds and shows success message).

## Why
`VITE_*` variables are exposed in the browser bundle. Keeping a mail API key in frontend code is a credential leak risk.

## Verification
- `npm run lint:frontend` passes
- `npx tsc -b` passes
- `grep` for `VITE_MAIL_API_KEY|X-Api-Key|VITE_MAIL_API_URL` in `src/` returns no matches

## Notes
Mail delivery is expected to happen server-side (Firestore/Cloud Functions trigger path), not from browser code.
