### PR TITLE
fix: booking ui and prevent api deletion in ftps deploy

### DIFF
--- a/.github/workflows/deploy-allinkl-ftps.yml
+++ b/.github/workflows/deploy-allinkl-ftps.yml
@@ -38,4 +38,5 @@ jobs:
           port: 21
           local-dir: dist/
           server-dir: ${{ secrets.ALLINKL_SERVER_DIR }}
-          dangerous-clean-slate: true
+          # Keep existing server files (for example /api) untouched.
+          dangerous-clean-slate: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
 import { NavBar } from "./components/NavBar";
 import { AppRoutes } from "./app/routes";
+import { useLocation } from "react-router-dom";
 
 export default function App() {
+  const { pathname } = useLocation();
+  const isBookingPage = pathname.startsWith("/book");
+
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
       <NavBar />
@@ -21,12 +25,14 @@ export default function App() {
 
       {/* Mobile Footer (fixed) */}
       <footer className="fixed inset-x-0 bottom-0 z-40 block bg-white/95 p-3 shadow md:hidden">
-        <button
-          onClick={() => location.assign("/book")}
-          className="w-full rounded-xl bg-[color:var(--ocean,#0e7490)] py-3 text-center font-semibold text-white"
-        >
-          Jetzt buchen
-        </button>
+        {!isBookingPage && (
+          <button
+            onClick={() => location.assign("/book")}
+            className="w-full rounded-xl bg-[color:var(--ocean,#0e7490)] py-3 text-center font-semibold text-white"
+          >
+            Jetzt buchen
+          </button>
+        )}
         <div className="mt-2 text-center text-xs text-slate-500">
           <a href="/impressum" className="mx-2 underline">Impressum</a>
           <span aria-hidden>·</span>


### PR DESCRIPTION
## Hintergrund
Auf der Buchungsseite (`/book`) wurden zwei Buttons angezeigt (`Anfrage senden` + `Jetzt buchen`).
Zusätzlich hat unser FTPS-Deploy durch `dangerous-clean-slate: true` serverseitige Dateien entfernt, inkl. Risiko für `/api`.

## Änderungen
- `src/App.tsx`
  - Mobile Footer-Button `Jetzt buchen` wird auf `/book` ausgeblendet.
- `src/pages/Booking.tsx`
  - Submit-Flow robuster gemacht (Form-Submit, klare Validierung, klare Toast-Meldungen für Mail-Erfolg/-Fehler).
- `.github/workflows/deploy-allinkl-ftps.yml`
  - `dangerous-clean-slate` auf `false` gesetzt, damit bestehende Server-Dateien (z. B. `/api`) nicht gelöscht werden.

## Verifikation
- `npm run lint:frontend` ✅
- `npm run build` ✅
- Auf `/book` ist nur noch ein primärer Submit-Button sichtbar ✅
- Mailversand über `Anfrage senden` funktioniert wieder ✅

## Hinweis
Frontend-Deploy und PHP-API sind damit sauberer getrennt.
Änderungen im `api/`-Ordner müssen weiterhin separat deployt werden.
