### PR TITLE
fix(deploy): validate and inject firebase env vars in production build

### DIFF
--- a/.github/workflows/deploy-allinkl-ftps.yml
+++ b/.github/workflows/deploy-allinkl-ftps.yml
@@ -25,7 +25,44 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate required frontend env vars
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for v in \
+            VITE_FIREBASE_API_KEY \
+            VITE_FIREBASE_AUTH_DOMAIN \
+            VITE_FIREBASE_PROJECT_ID \
+            VITE_FIREBASE_STORAGE_BUCKET \
+            VITE_FIREBASE_MESSAGING_SENDER_ID \
+            VITE_FIREBASE_APP_ID
+          do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Missing required secret: $v"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Build (Vite)
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_MAIL_API_URL: ${{ secrets.VITE_MAIL_API_URL }}
+          VITE_DEFAULT_PROPERTY_ID: ${{ secrets.VITE_DEFAULT_PROPERTY_ID }}
         run: npm run build
 
       - name: Deploy via FTPS (mirror)


### PR DESCRIPTION
Hintergrund
Nach Auto-Deploy über GitHub Actions lief die Live-Seite mit Firebase-Fehlern (auth/invalid-api-key), während manueller Upload funktionierte.

Ursache
Der Workflow hat das Frontend gebaut, ohne die benötigten VITE_FIREBASE_* Variablen in den Build zu injizieren. Dadurch wurde ein ungültiges Bundle deployed.

Änderungen
[deploy-allinkl-ftps.yml](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
Neuer Schritt Validate required frontend env vars
Build-Step bekommt explizit ENV aus GitHub Secrets:
VITE_FIREBASE_API_KEY
VITE_FIREBASE_AUTH_DOMAIN
VITE_FIREBASE_PROJECT_ID
VITE_FIREBASE_STORAGE_BUCKET
VITE_FIREBASE_MESSAGING_SENDER_ID
VITE_FIREBASE_APP_ID
VITE_MAIL_API_URL
VITE_DEFAULT_PROPERTY_ID
dangerous-clean-slate: false bleibt aktiv, damit bestehende Serverbereiche wie /api nicht gelöscht werden.
Erwartetes Ergebnis
Deploy bricht früh und eindeutig ab, wenn ein Pflicht-Secret fehlt.
Bei gesetzten Secrets wird ein valides Production-Bundle gebaut.
Keine auth/invalid-api-key Fehler mehr durch fehlende Build-ENVs.
Checkliste
 Alle oben genannten Secrets sind in Settings -> Secrets and variables -> Actions gesetzt.
 Workflow läuft auf dem Branch erfolgreich durch.
 Nach Merge läuft die Live-Seite ohne Firebase-Initialisierungsfehler.