### PR TITLE
fix(booking): improve responsive layout for tablet widths

### DIFF
--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -353,8 +353,8 @@ export default function Booking() {
       </header>
 
       {/* Formular */}
-      <form id="booking-form" className="grid gap-4 md:grid-cols-4" onSubmit={submitRequest}>
-        <div className="md:col-span-4">
+      <form id="booking-form" className="grid gap-4 lg:grid-cols-4" onSubmit={submitRequest}>
+        <div className="lg:col-span-4">
           <Field label="Zeitraum wählen">
             <DayPicker
               mode="range"
@@ -375,7 +375,7 @@ export default function Booking() {
         </Field>
 
         {/* Kontakt */}
-        <div className="md:col-span-4 grid gap-4 md:grid-cols-3">
+        <div className="lg:col-span-4 grid gap-4 lg:grid-cols-3">
           <Field label="Name">
             <input className="input" value={name} onChange={(e)=>setName(e.target.value)} placeholder="Vor- und Nachname" />
           </Field>
@@ -387,7 +387,7 @@ export default function Booking() {
           </Field>
 
           {/* NEU: Anschrift */}
-          <div className="md:col-span-3 grid gap-4 md:grid-cols-3">
+          <div className="lg:col-span-3 grid gap-4 lg:grid-cols-3">
             <Field label="Straße & Nr.">
               <input
                 className="input"
@@ -422,7 +422,7 @@ export default function Booking() {
             </Field>
           </div>
 
-          <div className="md:col-span-3">
+          <div className="lg:col-span-3">
             <Field label="Nachricht (optional)">
               <textarea className="input" rows={3} value={message} onChange={(e)=>setMessage(e.target.value)} placeholder="z.B. Ankunftszeit, Fragen …" />
             </Field>
@@ -437,7 +437,7 @@ export default function Booking() {
         ) : nights <= 0 ? (
           <p className="text-slate-600">Bitte ein gültiges Datum wählen (mindestens eine Nacht).</p>
         ) : calc ? (
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 lg:grid-cols-2">
             <div className="space-y-1">
               <h3 className="text-lg font-semibold">Zusammenfassung</h3>
               <Row label="Nächte" value={String(nights)} />
@@ -457,7 +457,7 @@ export default function Booking() {
                 <li>Kurtaxe je Nacht pro zahlender Person (≥16) gemäß Kurtaxe-Band.</li>
               </ul>
             </div>
-            <div className="md:col-span-2">
+            <div className="lg:col-span-2">
               <details className="rounded-lg border border-slate-200 bg-slate-50 p-3 open:bg-white">
                 <summary className="cursor-pointer select-none font-medium">Preis je Nacht anzeigen</summary>
                 <div className="mt-2 overflow-x-auto">
@@ -520,7 +520,7 @@ export default function Booking() {
         <p className="text-sm text-amber-700">Mindestaufenthalt: {MIN_NIGHTS} Nächte.</p>
       )}
 
-      <div className="text-right space-y-2">
+      <div className="space-y-2 lg:text-right">
         <button
           type="submit"
           className="rounded-xl bg-[color:var(--ocean,#0e7490)] px-5 py-2 font-semibold text-white hover:opacity-90 disabled:opacity-60"
@@ -566,9 +566,9 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 function Row({ label, value, bold }: { label: string; value: string; bold?: boolean }) {
   return (
-    <div className={["flex justify-between", bold ? "font-semibold" : ""].filter(Boolean).join(" ") }>
-      <span>{label}</span>
-      <span>{value}</span>
+    <div className={["flex items-start justify-between gap-3", bold ? "font-semibold" : ""].filter(Boolean).join(" ") }>
+      <span className="min-w-0">{label}</span>
+      <span className="shrink-0 text-right">{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR fixes a responsive layout issue on the booking page around tablet/small-desktop widths (~768–1024px), where content blocks (especially pricing summary and hints) could collide or become hard to read.

## Problem
At `md` breakpoints, the booking form and result sections switched to multi-column layouts too early.  
On narrower tablet widths, this caused visual overlap and poor readability.

## Changes
### `src/pages/Booking.tsx`
- Shifted key layout breakpoints from `md` to `lg` in the booking form/result grids:
  - main form grid
  - contact/address sub-grids
  - pricing summary/hints grid
  - wide details section span
- Adjusted CTA alignment so right-alignment applies only on larger screens.
- Hardened the `Row` component used in pricing lines:
  - added spacing and alignment guards
  - prevented value column from collapsing (`shrink-0`)
  - improved behavior under constrained widths

## Why this works
Keeping the page single-column longer avoids premature horizontal compression in the 768–1024px range.  
The `Row` changes ensure label/value pairs remain readable even when space is tight.

## Validation
- `npm run lint:frontend` ✅
- `npm run build` ✅

## Scope / Risk
- Scope is limited to booking-page presentation.
- No business logic or API behavior changed.
- Low functional risk; visual/layout-only change.
