### PR TITLE
security: remove frontend mail key usage and require bearer auth for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # React + TypeScript + Vite
 
+## Mail Security Flow (No Frontend API Key)
+
+- `booking_request` is sent from the frontend to `VITE_MAIL_API_URL` (fallback: `/api/send-booking-mail.php`) without a secret header.
+- `admin_action` is sent with `Authorization: Bearer <Firebase ID token>` from the logged-in admin session.
+- The PHP endpoint verifies the Firebase token via Identity Toolkit (`accounts:lookup`) and only allows emails from `ADMIN_EMAILS` (fallback: `OWNER_EMAIL`).
+- `VITE_MAIL_API_KEY` is intentionally removed from frontend usage and can be deleted from local env files and GitHub Secrets.
+
+Server-side `backend-php/config.php` must provide at least:
+
+- `FIREBASE_API_KEY`
+- `ADMIN_EMAILS`
+- SMTP settings (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, ...)
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -259,50 +259,45 @@ export default function Booking() {
 
       // Ohne Blaze: Mailversand direkt über den PHP-Endpoint (ohne Frontend-API-Key).
       try {
-        const mailUrl = import.meta.env.VITE_MAIL_API_URL as string | undefined;
-        if (!mailUrl) {
-          mailErrorText = "VITE_MAIL_API_URL ist nicht gesetzt.";
-          console.warn("[mail] skipped – VITE_MAIL_API_URL not set");
-        } else {
-          console.log("[mail] POST →", mailUrl);
-          const resp = await fetch(mailUrl, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
+        const mailUrl = (import.meta.env.VITE_MAIL_API_URL as string | undefined)?.trim() || "/api/send-booking-mail.php";
+        console.log("[mail] POST →", mailUrl);
+        const resp = await fetch(mailUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            type: "booking_request",
+            propertyId: String(propertyId),
+            propertyName,
+            startDate: startISO,
+            endDate: endISO,
+            adults: adultsNum,
+            children: childrenNum,
+            contact: {
+              name: nameClean,
+              email: emailClean,
+              phone: phoneClean,
+              address: { street, zip, city, country },
             },
-            body: JSON.stringify({
-              type: "booking_request",
-              propertyId: String(propertyId),
-              propertyName,
-              startDate: startISO,
-              endDate: endISO,
-              adults: adultsNum,
-              children: childrenNum,
-              contact: {
-                name: nameClean,
-                email: emailClean,
-                phone: phoneClean,
-                address: { street, zip, city, country },
-              },
-              message: messageClean,
-            }),
-          });
+            message: messageClean,
+          }),
+        });
 
-          const payload = await resp.json().catch(() => null) as
-            | { ok?: boolean; error?: string; status?: { owner?: string; guest?: string } }
-            | null;
+        const payload = await resp.json().catch(() => null) as
+          | { ok?: boolean; error?: string; status?: { owner?: string; guest?: string } }
+          | null;
 
-          mailSent = resp.ok && payload?.ok !== false;
-          if (!mailSent) {
-            const ownerStatus = payload?.status?.owner;
-            const guestStatus = payload?.status?.guest;
-            const serverError = payload?.error;
-            mailErrorText = [serverError, ownerStatus, guestStatus].filter(Boolean).join(" | ");
-            if (!mailErrorText) mailErrorText = `HTTP ${resp.status}`;
-            console.warn("[mail] send failed", resp.status, payload);
-          } else {
-            console.log("[mail] send ok", payload);
-          }
+        mailSent = resp.ok && payload?.ok !== false;
+        if (!mailSent) {
+          const ownerStatus = payload?.status?.owner;
+          const guestStatus = payload?.status?.guest;
+          const serverError = payload?.error;
+          mailErrorText = [serverError, ownerStatus, guestStatus].filter(Boolean).join(" | ");
+          if (!mailErrorText) mailErrorText = `HTTP ${resp.status}`;
+          console.warn("[mail] send failed", resp.status, payload);
+        } else {
+          console.log("[mail] send ok", payload);
         }
       } catch (err) {
         mailErrorText = err instanceof Error ? err.message : "fetch_failed";


### PR DESCRIPTION
## Summary
- remove client-side secret header usage from mail flows
- send admin action mails with Firebase Bearer token from authenticated admin session
- add fallback `/api/send-booking-mail.php` for booking mail endpoint when `VITE_MAIL_API_URL` is unset
- document the no-frontend-secret mail flow in README

## Security impact
- `VITE_MAIL_API_KEY` is no longer used in frontend code or bundled output
- admin mail authorization is expected server-side via Firebase token verification and admin allowlist

## Validation
- npm run lint:frontend
- npm run build:frontend

## Notes
- `backend-php/` is gitignored in this repo, so server-side PHP changes must be deployed manually to the `/api` directory on the host.
