### PR TITLE
a11y: implement semantic tab pattern in admin dashboard

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { signOut } from "firebase/auth";
 import { auth } from "../lib/firebase";
 import PropertyForm from "../components/admin/PropertyForm";
@@ -9,12 +9,35 @@ import BookingsTable from "../components/admin/BookingsTable";
 import { cancelBooking } from "../lib/db";
 import OccupancyCalendar from "../components/admin/OccupancyCalendar";
 
+type TabKey = "property" | "seasons" | "taxes" | "bookings" | "calendar";
+
+const ADMIN_TABS: ReadonlyArray<{ key: TabKey; label: string }> = [
+  { key: "property", label: "Stammdaten" },
+  { key: "seasons", label: "Saisonpreise" },
+  { key: "taxes", label: "Kurtaxe" },
+  { key: "bookings", label: "Anfragen" },
+  { key: "calendar", label: "Kalender" },
+];
+
+function tabId(key: TabKey): string {
+  return `admin-tab-${key}`;
+}
+
+function panelId(key: TabKey): string {
+  return `admin-panel-${key}`;
+}
+
 export default function AdminDashboard() {
-  const [tab, setTab] = useState<"property" | "seasons" | "taxes" | "bookings" | "calendar">(
-    "property"
-  );
+  const [tab, setTab] = useState<TabKey>("property");
   const [propertyId, setPropertyId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const tabRefs = useRef<Record<TabKey, HTMLButtonElement | null>>({
+    property: null,
+    seasons: null,
+    taxes: null,
+    bookings: null,
+    calendar: null,
+  });
 
   async function handleLogout() {
     await signOut(auth);
@@ -29,6 +52,31 @@ export default function AdminDashboard() {
     })();
   }, []);
 
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>, key: TabKey) {
+    const currentIndex = ADMIN_TABS.findIndex((tabItem) => tabItem.key === key);
+    if (currentIndex < 0) return;
+
+    let nextIndex = currentIndex;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = (currentIndex + 1) % ADMIN_TABS.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = (currentIndex - 1 + ADMIN_TABS.length) % ADMIN_TABS.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = ADMIN_TABS.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    const nextTab = ADMIN_TABS[nextIndex].key;
+    setTab(nextTab);
+    requestAnimationFrame(() => {
+      tabRefs.current[nextTab]?.focus();
+    });
+  }
+
   return (
     <section className="space-y-6">
       <div className="flex items-center justify-between">
@@ -42,134 +90,128 @@ export default function AdminDashboard() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-2">
-        <button
-          className={[
-            "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium",
-            tab === "property"
-              ? "bg-[color:var(--ocean,#0e7490)] text-white"
-              : "bg-white text-slate-700 border border-slate-200 hover:bg-slate-50",
-          ].join(" ")}
-          onClick={() => setTab("property")}
-        >
-          Stammdaten
-        </button>
-        <button
-          className={[
-            "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium",
-            tab === "seasons"
-              ? "bg-[color:var(--ocean,#0e7490)] text-white"
-              : "bg-white text-slate-700 border border-slate-200 hover:bg-slate-50",
-          ].join(" ")}
-          onClick={() => setTab("seasons")}
-        >
-          Saisonpreise
-        </button>
-        <button
-          className={[
-            "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium",
-            tab === "taxes"
-              ? "bg-[color:var(--ocean,#0e7490)] text-white"
-              : "bg-white text-slate-700 border border-slate-200 hover:bg-slate-50",
-          ].join(" ")}
-          onClick={() => setTab("taxes")}
-        >
-          Kurtaxe
-        </button>
-        <button
-          className={[
-            "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium",
-            tab === "bookings"
-              ? "bg-[color:var(--ocean,#0e7490)] text-white"
-              : "bg-white text-slate-700 border border-slate-200 hover:bg-slate-50",
-          ].join(" ")}
-          onClick={() => setTab("bookings")}
-        >
-          Anfragen
-        </button>
-        <button
-          className={[
-            "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium",
-            tab === "calendar"
-              ? "bg-[color:var(--ocean,#0e7490)] text-white"
-              : "bg-white text-slate-700 border border-slate-200 hover:bg-slate-50",
-          ].join(" ")}
-          onClick={() => setTab("calendar")}
-        >
-          Kalender
-        </button>
+      <div role="tablist" aria-label="Admin Bereiche" className="flex flex-wrap gap-2">
+        {ADMIN_TABS.map((tabItem) => {
+          const isActive = tab === tabItem.key;
+          return (
+            <button
+              key={tabItem.key}
+              ref={(element) => {
+                tabRefs.current[tabItem.key] = element;
+              }}
+              id={tabId(tabItem.key)}
+              role="tab"
+              type="button"
+              aria-selected={isActive}
+              aria-controls={panelId(tabItem.key)}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setTab(tabItem.key)}
+              onKeyDown={(event) => handleTabKeyDown(event, tabItem.key)}
+              className={[
+                "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400",
+                isActive
+                  ? "bg-[color:var(--ocean,#0e7490)] text-white"
+                  : "bg-white text-slate-700 border border-slate-200 hover:bg-slate-50",
+              ].join(" ")}
+            >
+              {tabItem.label}
+            </button>
+          );
+        })}
       </div>
 
       {/* Panels */}
       <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-        {tab === "property" && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">
-              Stammdaten der Ferienwohnung
-            </h2>
-            <PropertyForm />
-          </div>
-        )}
+        <section
+          id={panelId("property")}
+          role="tabpanel"
+          aria-labelledby={tabId("property")}
+          hidden={tab !== "property"}
+          className="space-y-4"
+        >
+          <h2 className="text-lg font-semibold">Stammdaten der Ferienwohnung</h2>
+          <PropertyForm />
+        </section>
 
-        {tab === "seasons" && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Saisonpreise verwalten</h2>
-            {loading ? (
-              <p className="text-slate-600">Laden…</p>
-            ) : propertyId ? (
-              <SeasonsTable propertyId={propertyId} />
-            ) : (
-              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
-                Bitte lege zuerst unter <strong>Stammdaten</strong> eine
-                Unterkunft an. Danach kannst du hier Saisonpreise erfassen.
-              </div>
-            )}
-          </div>
-        )}
-        {tab === "taxes" && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Kurtaxe verwalten</h2>
-            {loading ? (
-              <p className="text-slate-600">Laden…</p>
-            ) : propertyId ? (
-              <TaxesTable propertyId={propertyId} />
-            ) : (
-              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
-                Bitte lege zuerst unter <strong>Stammdaten</strong> eine
-                Unterkunft an. Danach kannst du hier Kurtaxe-Bänder erfassen.
-              </div>
-            )}
-          </div>
-        )}
-        {tab === "bookings" && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Buchungsanfragen</h2>
-            {loading ? (
-              <p className="text-slate-600">Laden…</p>
-            ) : propertyId ? (
-              <BookingsTable propertyId={propertyId} onCancel={cancelBooking} />
-            ) : (
-              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
-                Bitte lege zuerst unter <strong>Stammdaten</strong> eine
-                Unterkunft an. Danach kannst du hier Anfragen verwalten.
-              </div>
-            )}
-          </div>
-        )}
-        {tab === "calendar" && (
-          <div className="space-y-4">
-            <h2 className="text-lg font-semibold">Kalender</h2>
-            {loading ? (
-              <p className="text-slate-600">Laden…</p>
-            ) : propertyId ? (
-              <OccupancyCalendar propertyId={propertyId} />
-            ) : (
-              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
-                Bitte lege zuerst unter <strong>Stammdaten</strong> eine Unterkunft an. Danach kannst du hier den Belegungskalender nutzen.
-              </div>
-            )}
-          </div>
-        )}
+        <section
+          id={panelId("seasons")}
+          role="tabpanel"
+          aria-labelledby={tabId("seasons")}
+          hidden={tab !== "seasons"}
+          className="space-y-4"
+        >
+          <h2 className="text-lg font-semibold">Saisonpreise verwalten</h2>
+          {loading ? (
+            <p className="text-slate-600">Laden…</p>
+          ) : propertyId ? (
+            <SeasonsTable propertyId={propertyId} />
+          ) : (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
+              Bitte lege zuerst unter <strong>Stammdaten</strong> eine Unterkunft
+              an. Danach kannst du hier Saisonpreise erfassen.
+            </div>
+          )}
+        </section>
+
+        <section
+          id={panelId("taxes")}
+          role="tabpanel"
+          aria-labelledby={tabId("taxes")}
+          hidden={tab !== "taxes"}
+          className="space-y-4"
+        >
+          <h2 className="text-lg font-semibold">Kurtaxe verwalten</h2>
+          {loading ? (
+            <p className="text-slate-600">Laden…</p>
+          ) : propertyId ? (
+            <TaxesTable propertyId={propertyId} />
+          ) : (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
+              Bitte lege zuerst unter <strong>Stammdaten</strong> eine Unterkunft
+              an. Danach kannst du hier Kurtaxe-Bänder erfassen.
+            </div>
+          )}
+        </section>
+
+        <section
+          id={panelId("bookings")}
+          role="tabpanel"
+          aria-labelledby={tabId("bookings")}
+          hidden={tab !== "bookings"}
+          className="space-y-4"
+        >
+          <h2 className="text-lg font-semibold">Buchungsanfragen</h2>
+          {loading ? (
+            <p className="text-slate-600">Laden…</p>
+          ) : propertyId ? (
+            <BookingsTable propertyId={propertyId} onCancel={cancelBooking} />
+          ) : (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
+              Bitte lege zuerst unter <strong>Stammdaten</strong> eine Unterkunft
+              an. Danach kannst du hier Anfragen verwalten.
+            </div>
+          )}
+        </section>
+
+        <section
+          id={panelId("calendar")}
+          role="tabpanel"
+          aria-labelledby={tabId("calendar")}
+          hidden={tab !== "calendar"}
+          className="space-y-4"
+        >
+          <h2 className="text-lg font-semibold">Kalender</h2>
+          {loading ? (
+            <p className="text-slate-600">Laden…</p>
+          ) : propertyId ? (
+            <OccupancyCalendar propertyId={propertyId} />
+          ) : (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900">
+              Bitte lege zuerst unter <strong>Stammdaten</strong> eine Unterkunft
+              an. Danach kannst du hier den Belegungskalender nutzen.
+            </div>
+          )}
+        </section>
       </div>
     </section>
   );


### PR DESCRIPTION
Summary
Implement semantic tab navigation in the admin dashboard.
Add proper WAI-ARIA relationships between tabs and tab panels.
Improve keyboard accessibility for tab navigation without changing business logic.
What Changed
Added role="tablist" to the admin tab container.
Converted each tab trigger to a semantic tab with:
role="tab"
aria-selected
aria-controls
stable id
roving tabIndex (active tab is focusable, inactive tabs are not in tab order)
Converted each content section to a semantic panel with:
role="tabpanel"
aria-labelledby
stable id
hidden when inactive
Added keyboard support for tab navigation:
ArrowLeft / ArrowRight
ArrowUp / ArrowDown
Home / End
Refactored tab metadata into a typed tab config for consistent ids/labels.
Accessibility Impact
Screen readers can now identify the tablist, active tab, and associated panel correctly.
Keyboard-only users can navigate tabs according to expected tab pattern behavior.
Validation
npm run lint:frontend passed
npm run build:frontend passed
Scope
File changed: [AdminDashboard.tsx](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)