### PR TITLE
a11y: standardize modal dialog semantics across gallery and admin ove…

### DIFF
--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { buildGalleryImagePath, GALLERY_IMAGES } from "../lib/galleryImages";
 
 export default function Gallery() {
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const lightboxTitleId = useId();
 
   const closeLightbox = () => setActiveIndex(null);
   const showPrevious = () =>
@@ -34,6 +36,7 @@ export default function Gallery() {
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     window.addEventListener("keydown", handleKeyDown);
+    closeButtonRef.current?.focus();
 
     return () => {
       document.body.style.overflow = previousOverflow;
@@ -78,9 +81,11 @@ export default function Gallery() {
           onClick={closeLightbox}
           role="dialog"
           aria-modal="true"
-          aria-label="Große Bildansicht"
+          aria-labelledby={lightboxTitleId}
         >
+          <h2 id={lightboxTitleId} className="sr-only">Große Bildansicht</h2>
           <button
+            ref={closeButtonRef}
             type="button"
             onClick={closeLightbox}
             className="absolute right-3 top-3 rounded-md bg-white/90 px-3 py-2 text-sm font-medium text-slate-900 hover:bg-white md:right-6 md:top-6"


### PR DESCRIPTION
Summary
Standardized modal dialog semantics across gallery and admin overlays.
Ensured all affected dialogs expose an accessible name via aria-labelledby.
Made Escape-to-close behavior consistent for keyboard users.
Scope
[OccupancyCalendar.tsx](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[BookingsTable.tsx](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[Gallery.tsx](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
What Changed
1) OccupancyCalendar confirm overlay
Added semantic dialog attributes to the cancel confirmation modal:
role="dialog"
aria-modal="true"
aria-labelledby linked to the modal title id
Added Escape key handling to close the confirmation modal.
Added explicit type="button" for modal action buttons.
2) BookingsTable modal behavior + labeling
Updated global Escape handling to close whichever modal is currently open:
close confirm modal first
otherwise close details modal
Enhanced LightModal component:
added aria-labelledby bound to a generated heading id
auto-focuses the close button on open for reliable keyboard entry point
explicit type="button" on close button
3) Gallery lightbox consistency
Replaced generic aria-label with aria-labelledby and a dedicated hidden heading.
Auto-focuses the close button when lightbox opens.
Keeps existing keyboard behavior (Escape/ArrowLeft/ArrowRight) and backdrop click close behavior.
Accessibility Impact
All reviewed overlays now expose proper dialog semantics and an explicit accessible name.
Keyboard-only users can consistently close dialogs via Escape and reachable controls.
No unlabeled dialog remains in the scoped components.
Validation
npm run lint:frontend passed
npm run build:frontend passed