### PR TITLE
a11y: improve semantic html in public forms and content sections

### DIFF
--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -434,18 +434,22 @@ export default function Booking() {
         ) : calc ? (
           <div className="grid gap-4">
             <div className="space-y-1">
-              <h3 className="text-lg font-semibold">Zusammenfassung</h3>
-              <Row label="Nächte" value={String(nights)} />
-              <Row label="Übernachtungen" value={fmt.format(calc.base.nightsTotal)} />
-              <Row label="Endreinigung" value={fmt.format(calc.base.cleaningFee)} />
-              <Row label="Kurtaxe (Erwachsene)" value={fmt.format(calc.tax.total)} />
+              <h2 className="text-lg font-semibold">Zusammenfassung</h2>
+              <dl className="space-y-1">
+                <SummaryItem label="Nächte" value={String(nights)} />
+                <SummaryItem label="Übernachtungen" value={fmt.format(calc.base.nightsTotal)} />
+                <SummaryItem label="Endreinigung" value={fmt.format(calc.base.cleaningFee)} />
+                <SummaryItem label="Kurtaxe (Erwachsene)" value={fmt.format(calc.tax.total)} />
+              </dl>
               <div className="mt-2 h-px bg-slate-200" />
-              <Row label="Gesamt" value={fmt.format(calc.grandTotal)} bold />
+              <dl>
+                <SummaryItem label="Gesamt" value={fmt.format(calc.grandTotal)} bold />
+              </dl>
               <p className="mt-2 text-xs text-slate-500">Kurtaxe ab 16 Jahren. Saisonpreise inkl. USt., Kurtaxe nach Ortsrecht.</p>
             </div>
 
             <div className="space-y-2">
-              <h4 className="font-medium">Hinweise</h4>
+              <h3 className="font-medium">Hinweise</h3>
               <ul className="list-disc pl-5 text-sm text-slate-700">
                 <li><strong>Ende exkl.:</strong> Die Abreise-Nacht ist nicht berechnet.</li>
                 <li>In definierten Saisons gilt der jeweilige Nachtpreis. Außerhalb gilt der Standardpreis.</li>
@@ -563,11 +567,11 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-function Row({ label, value, bold }: { label: string; value: string; bold?: boolean }) {
+function SummaryItem({ label, value, bold }: { label: string; value: string; bold?: boolean }) {
   return (
     <div className={["flex items-start justify-between gap-3", bold ? "font-semibold" : ""].filter(Boolean).join(" ") }>
-      <span className="min-w-0">{label}</span>
-      <span className="shrink-0 text-right">{value}</span>
+      <dt className="min-w-0">{label}</dt>
+      <dd className="shrink-0 text-right">{value}</dd>
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -63,23 +63,29 @@ export default function Home() {
           </p>
 
           <form className="mt-4 grid gap-3 md:grid-cols-4">
-            <input
-              className="rounded-lg border p-3 md:col-span-1"
-              type="date"
-              aria-label="Anreise"
-            />
-            <input
-              className="rounded-lg border p-3 md:col-span-1"
-              type="date"
-              aria-label="Abreise"
-            />
-            <input
-              className="rounded-lg border p-3 md:col-span-1"
-              type="number"
-              min={1}
-              defaultValue={2}
-              aria-label="Gäste"
-            />
+            <label className="md:col-span-1">
+              <span className="mb-1 block text-sm text-slate-700">Anreise</span>
+              <input
+                className="w-full rounded-lg border p-3"
+                type="date"
+              />
+            </label>
+            <label className="md:col-span-1">
+              <span className="mb-1 block text-sm text-slate-700">Abreise</span>
+              <input
+                className="w-full rounded-lg border p-3"
+                type="date"
+              />
+            </label>
+            <label className="md:col-span-1">
+              <span className="mb-1 block text-sm text-slate-700">Gäste</span>
+              <input
+                className="w-full rounded-lg border p-3"
+                type="number"
+                min={1}
+                defaultValue={2}
+              />
+            </label>
             <button
               className="rounded-lg bg-[color:var(--ocean,#0e7490)] px-5 py-3 font-medium text-white hover:opacity-90"
               type="button"
@@ -92,6 +98,7 @@ export default function Home() {
       </div>
 
       <section className="mt-8 bg-[color:var(--sand,#f4ede4)] py-8 md:mt-12 md:py-12">
+        <h2 className="sr-only">Ausstattungsmerkmale</h2>
         <div className="mx-auto grid max-w-6xl gap-4 px-4 md:grid-cols-4">
           {[
             { t: "Strandnah", d: "20 Minuten zu Fuß" },
@@ -99,10 +106,10 @@ export default function Home() {
             { t: "Haustiere erlaubt", d: "auf Anfrage" },
             { t: "WLAN & Smart-TV", d: "inklusive" },
           ].map((it) => (
-            <div key={it.t} className="rounded-xl bg-white p-4 shadow-sm">
+            <article key={it.t} className="rounded-xl bg-white p-4 shadow-sm">
               <h3 className="text-base font-semibold text-slate-900">{it.t}</h3>
               <p className="text-sm text-slate-600">{it.d}</p>
-            </div>
+            </article>
           ))}
         </div>
       </section>

--- a/src/pages/Imprint.tsx
+++ b/src/pages/Imprint.tsx
@@ -1,13 +1,19 @@
 export default function Imprint() {
   return (
-    <div className="max-w-3xl mx-auto p-6 prose">
+    <section className="max-w-3xl mx-auto p-6 prose">
       <h1 className="text-2xl font-bold mb-6">Impressum</h1>
-      <p className="mb-4"><strong>Antja & Siebo Remmers</strong></p>
-      <p className="mb-4">Spangerstr. 9<br />27476 Cuxhaven</p>
-      <p className="mb-4">
-        E-Mail: <a href="mailto:mutzi@antjes-ankerplatz.net">mutzi@antjes-ankerplatz.net</a>
-      </p>
-      <p className="mb-4">Telefon: 04721 - 21508</p>
+      <address className="not-italic mb-4">
+        <p className="mb-4"><strong>Antja & Siebo Remmers</strong></p>
+        <p className="mb-4">
+          Spangerstr. 9
+          <br />
+          27476 Cuxhaven
+        </p>
+        <p className="mb-4">
+          E-Mail: <a href="mailto:mutzi@antjes-ankerplatz.net">mutzi@antjes-ankerplatz.net</a>
+        </p>
+        <p className="mb-4">Telefon: 04721 - 21508</p>
+      </address>
       <p className="mb-4">
         <strong>Verantwortlich im Sinne des § 5 TMG:</strong> Antja & Siebo Remmers
       </p>
@@ -22,6 +28,6 @@ export default function Imprint() {
       <p className="mb-4">
         Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht.
       </p>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Improved semantic HTML on public pages to better reflect content meaning and improve accessibility.
- Added explicit form labels on Home.
- Replaced visual key/value summary structure in Booking with semantic description lists.
- Updated legal contact markup in Imprint to use an `address` element.
- Reviewed and improved heading structure consistency in affected sections.

## Scope
- `src/pages/Home.tsx`
- `src/pages/Booking.tsx`
- `src/pages/Imprint.tsx`

## What Changed

### `src/pages/Home.tsx`
- Added explicit `<label>` elements for:
  - arrival date
  - departure date
  - guest count
- Removed reliance on `aria-label`-only form labeling for those fields.
- Added a semantic section heading (`sr-only`) for the feature cards block.
- Converted feature card wrappers from generic `<div>` to `<article>`.

### `src/pages/Booking.tsx`
- Replaced summary key/value rows from generic layout elements to semantic:
  - `<dl>` container
  - `<dt>` term labels
  - `<dd>` values
- Updated related heading levels in the summary/hints block for clearer hierarchy.
- Preserved visual layout and pricing behavior.

### `src/pages/Imprint.tsx`
- Changed top-level wrapper from `<div>` to `<section>`.
- Wrapped contact information in a semantic `<address>` block (styled as non-italic to keep design).

## Accessibility Impact
- Form controls now have explicit label associations.
- Booking summary is now represented as structured descriptive data, not only visual alignment.
- Legal contact details use an appropriate semantic element.

## Validation
- `npm run lint:frontend` passed
- `npm run build:frontend` passed