### PR TITLE
ci: fix root lint script to use frontend flat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # React + TypeScript + Vite
 
+## Common Scripts
+
+- `npm run lint` runs frontend linting via the root flat-config setup (`npm run lint:frontend`).
+- `npm run build` builds the frontend bundle.
+- `npm run ci` runs frontend + functions lint/build checks in one command.
+
 ## Mail Security Flow (No Frontend API Key)
 
 - `booking_request` is sent from the frontend to `VITE_MAIL_API_URL` (fallback: `/api/send-booking-mail.php`) without a secret header.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:frontend": "vite build",
     "lint:functions": "npm --prefix functions run lint",
     "build:functions": "npm --prefix functions run build",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint \"src/**/*.{ts,tsx}\"",
+    "lint": "npm run lint:frontend",
     "build": "npm run build:frontend",
     "ci": "npm run lint:frontend && npm run build:frontend && npm run lint:functions && npm run build:functions"
   },


### PR DESCRIPTION
## Summary
- Fixed the root lint command to use the frontend flat-config lint script consistently.
- Removed legacy root lint behavior that could cause config-mode mismatches.
- Added short script usage notes to README for local/CI consistency.

## Changes
- Updated root `lint` script in `package.json`:
  - from: `ESLINT_USE_FLAT_CONFIG=false eslint "src/**/*.{ts,tsx}"`
  - to: `npm run lint:frontend`
- Added a **Common Scripts** section in `README.md` documenting:
  - `npm run lint`
  - `npm run build`
  - `npm run ci`

## Why
The root lint command was inconsistent with the rest of the project and CI flow.  
This change ensures that local and CI linting both use the same frontend lint entrypoint and avoid flat-config mode conflicts.

## Validation
- `npm run lint` passed
- `npm run ci` passed

## Scope
- `package.json`
- `README.md`