### PR TITLE
ci: add explicit frontend typecheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  frontend_typecheck:
+    name: Frontend (typecheck)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install (root)
+        run: npm ci
+
+      - name: Typecheck (frontend)
+        run: npm run typecheck:frontend
+
   frontend:
     name: Frontend (lint, build)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "dev": "vite",
     "preview": "vite preview",
     "lint:frontend": "eslint \"src/**/*.{ts,tsx}\"",
+    "typecheck:frontend": "tsc -b",
     "build:frontend": "vite build",
     "lint:functions": "npm --prefix functions run lint",
     "build:functions": "npm --prefix functions run build",
     "lint": "npm run lint:frontend",
     "build": "npm run build:frontend",
-    "ci": "npm run lint:frontend && npm run build:frontend && npm run lint:functions && npm run build:functions"
+    "ci": "npm run lint:frontend && npm run typecheck:frontend && npm run build:frontend && npm run lint:functions && npm run build:functions"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.1",


### PR DESCRIPTION
## Summary
This PR adds an explicit frontend TypeScript typecheck step to make CI feedback clearer and fail earlier on type errors.

## Changes
- Added new root script:
  - `typecheck:frontend`: `tsc -b`
- Updated root `ci` script to include frontend typecheck between lint and build.
- Added a dedicated CI job in `.github/workflows/ci.yml`:
  - `Frontend (typecheck)`
  - Runs `npm run typecheck:frontend`

## Why
Previously, frontend type errors were only discovered indirectly (or mixed with build output).  
A dedicated typecheck job makes failures explicit, faster to diagnose, and easier to track as a required status check.

## Validation
- `npm run typecheck:frontend` ✅
- `npm run lint` ✅
- `npm run ci` ✅

## Expected CI Result
CI now shows a separate frontend typecheck status in addition to existing frontend/functions lint/build checks.