### PR TITLE
backend: use indexed Firestore queries for booking overlap paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 - `npm run build` builds the frontend bundle.
 - `npm run ci` runs frontend + functions lint/build checks in one command.
 
+## Firestore Indexes (Booking Overlap Queries)
+
+Booking overlap/availability paths now use indexed server-side filters (no full booking fetch + client filtering).
+Required composite index is tracked in:
+
+- `firestore.indexes.json`
+- `firestore.indexes.remote.json`
+
+Index fields for `bookings`:
+
+- `propertyId` (ASC)
+- `status` (ASC)
+- `startDate` (ASC)
+- `endDate` (ASC)
+
 ## Mail Security Flow (No Frontend API Key)
 
 - `booking_request` is sent from the frontend to `VITE_MAIL_API_URL` (fallback: `/api/send-booking-mail.php`) without a secret header.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -31,6 +31,16 @@
       "density": "SPARSE_ALL"
     },
     {
+      "collectionGroup": "bookings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "startDate", "order": "ASCENDING" },
+        { "fieldPath": "endDate", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "publicHolds",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.indexes.remote.json
+++ b/firestore.indexes.remote.json
@@ -29,6 +29,16 @@
         }
       ],
       "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "bookings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "startDate", "order": "ASCENDING" },
+        { "fieldPath": "endDate", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
This PR removes client-side booking filtering in critical overlap paths and replaces it with indexed Firestore queries to improve scalability.

## Changes
- Refactored `listApprovedBookings` in `src/lib/db.ts`:
  - Uses Firestore query constraints (`propertyId`, `status`, optional overlap range)
  - No full collection fetch + in-memory filter
- Refactored `listOverlapBookings` in `src/lib/db.ts`:
  - Uses server-side overlap query with:
    - `propertyId == ...`
    - `status in ["approved", "requested"]`
    - `startDate < toISO`
    - `endDate > fromISO`
- Added composite `bookings` index to:
  - `firestore.indexes.json`
  - `firestore.indexes.remote.json`
- Added index documentation to `README.md`

## Why
The previous implementation loaded all bookings for a property and filtered in the client, which does not scale with growing data volume.

## Validation
- `npm run lint` ✅
- `npm run typecheck:frontend` ✅
- `npm run build:frontend` ✅
- `npm run ci` ✅

## Deployment Note
After merge, deploy Firestore indexes:
`firebase deploy --only firestore:indexes`
