### PR TITLE
docs: replace Vite template README with project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,255 @@
-# React + TypeScript + Vite
+# Antjes Ankerplatz
 
-## Common Scripts
+Booking and admin web app for a holiday apartment.
 
-- `npm run lint` runs frontend linting via the root flat-config setup (`npm run lint:frontend`).
-- `npm run build` builds the frontend bundle.
-- `npm run ci` runs frontend + functions lint/build checks in one command.
+This repository contains:
+- A Vite + React + TypeScript frontend
+- Firebase (Firestore/Auth) integration
+- Optional Firebase Cloud Functions mail flow
+- A PHP mail endpoint for production hosting on all-inkl (`/api/send-booking-mail.php`)
 
-## Firestore Indexes (Booking Overlap Queries)
+## Tech Stack
 
-Booking overlap/availability paths now use indexed server-side filters (no full booking fetch + client filtering).
-Required composite index is tracked in:
+- Frontend: React 19, TypeScript, Vite 7, Tailwind CSS
+- Data/Auth: Firebase Firestore + Firebase Auth
+- Backend options for mail:
+  - Firebase Functions (`functions/`)
+  - PHP endpoint (`backend-php/send-booking-mail.php`)
+- CI/CD: GitHub Actions
 
-- `firestore.indexes.json`
-- `firestore.indexes.remote.json`
+## Repository Structure
 
-Index fields for `bookings`:
+- `src/` frontend app
+- `functions/` Firebase Functions (TypeScript)
+- `backend-php/` PHP mail endpoint + Composer dependencies
+- `.github/workflows/ci.yml` CI checks
+- `.github/workflows/deploy-allinkl-ftps.yml` production frontend deploy (FTPS)
+- `firestore.rules` Firestore security rules
+- `firestore.indexes.json` Firestore indexes (source of truth)
 
-- `propertyId` (ASC)
-- `status` (ASC)
-- `startDate` (ASC)
-- `endDate` (ASC)
+## Prerequisites
 
-## Mail Security Flow (No Frontend API Key)
+- Node.js 22 (recommended; CI runs on Node 22)
+- npm
+- Firebase CLI (for rules/index/functions/emulators)
+- PHP + Composer (only if you work on `backend-php/`)
 
-- `booking_request` is sent from the frontend to `VITE_MAIL_API_URL` (fallback: `/api/send-booking-mail.php`) without a secret header.
-- `admin_action` is sent with `Authorization: Bearer <Firebase ID token>` from the logged-in admin session.
-- The PHP endpoint verifies the Firebase token via Identity Toolkit (`accounts:lookup`) and only allows emails from `ADMIN_EMAILS` (fallback: `OWNER_EMAIL`).
-- `VITE_MAIL_API_KEY` is intentionally removed from frontend usage and can be deleted from local env files and GitHub Secrets.
+## Local Setup
 
-Server-side `backend-php/config.php` must provide at least:
+### 1. Install dependencies
 
+```bash
+npm ci
+npm --prefix functions ci
+```
+
+### 2. Configure frontend env
+
+Create `.env.local` in repo root:
+
+```bash
+VITE_FIREBASE_API_KEY=...
+VITE_FIREBASE_AUTH_DOMAIN=...
+VITE_FIREBASE_PROJECT_ID=...
+VITE_FIREBASE_STORAGE_BUCKET=...
+VITE_FIREBASE_MESSAGING_SENDER_ID=...
+VITE_FIREBASE_APP_ID=...
+VITE_DEFAULT_PROPERTY_ID=...
+
+# optional
+VITE_MAIL_API_URL=http://localhost:8081/send-booking-mail.php
+VITE_ASSET_BASE_URL=
+VITE_FIRESTORE_DEBUG=0
+VITE_USE_EMULATORS=0
+VITE_AUTH_EMULATOR=0
+```
+
+Notes:
+- `VITE_DEFAULT_PROPERTY_ID` is required for booking/admin data loading.
+- If `VITE_MAIL_API_URL` is not set, frontend falls back to `/api/send-booking-mail.php`.
+
+### 3. Run frontend
+
+```bash
+npm run dev
+```
+
+### 4. Optional: run Firebase emulators
+
+```bash
+firebase emulators:start
+```
+
+(Ports configured in `firebase.json`.)
+
+### 5. Optional: run functions locally
+
+```bash
+npm --prefix functions run serve
+```
+
+## Scripts
+
+### Root
+
+- `npm run dev` start frontend dev server
+- `npm run preview` preview production build
+- `npm run lint:frontend` lint frontend
+- `npm run typecheck:frontend` TypeScript project references check (`tsc -b`)
+- `npm run build:frontend` build frontend
+- `npm run lint:functions` lint functions
+- `npm run build:functions` build functions
+- `npm run lint` alias for `lint:frontend`
+- `npm run build` alias for `build:frontend`
+- `npm run ci` run frontend + functions checks end-to-end
+
+### Functions (`functions/package.json`)
+
+- `npm --prefix functions run lint`
+- `npm --prefix functions run build`
+- `npm --prefix functions run serve`
+
+## Environment Variables and Secrets
+
+### Frontend env (`VITE_*`)
+
+Required:
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_STORAGE_BUCKET`
+- `VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `VITE_FIREBASE_APP_ID`
+- `VITE_DEFAULT_PROPERTY_ID`
+
+Optional:
+- `VITE_MAIL_API_URL`
+- `VITE_ASSET_BASE_URL`
+- `VITE_FIRESTORE_DEBUG`
+- `VITE_USE_EMULATORS`
+- `VITE_AUTH_EMULATOR`
+
+Important:
+- Do **not** use `VITE_MAIL_API_KEY`. The frontend no longer sends a mail API key.
+
+### Functions env (`process.env`)
+
+Used by `functions/src/mailer.ts` and `functions/src/index.ts`:
+- `OWNER_EMAIL`
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`
+- `SMTP_SECURE`
+- `FROM_EMAIL`
+- `SMTP_AUTH_METHOD`
+- `SMTP_REQUIRE_TLS`
+
+### PHP mail endpoint config (`backend-php/config.php`)
+
+Expected constants include:
 - `FIREBASE_API_KEY`
 - `ADMIN_EMAILS`
-- SMTP settings (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, ...)
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`
+- `FROM_EMAIL`, `FROM_NAME`, `OWNER_EMAIL`
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+`send-booking-mail.php` authorizes `admin_action` requests via Firebase ID token (`Authorization: Bearer ...`) and `ADMIN_EMAILS` allowlist.
 
-Currently, two official plugins are available:
+## Secret Handling Rules
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Never commit real secrets to Git.
+- Keep `.env*` files local/private.
+- Keep production PHP config private on server (`/api/config.php`).
+- Rotate credentials immediately if leaked.
 
-## Expanding the ESLint configuration
+## CI and Branch/PR Workflow
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+CI workflow: `.github/workflows/ci.yml`
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+Jobs:
+- `Frontend (typecheck)`
+- `Frontend (lint, build)`
+- `Functions (lint, build)`
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
+Recommended branch workflow:
+1. `git switch main && git pull --ff-only`
+2. `git switch -c <issue-branch>`
+3. implement + run local checks
+4. push branch
+5. open PR into `main`
+6. merge only after required checks are green (and review if required by ruleset)
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Deploy
+
+Production deploy workflow: `.github/workflows/deploy-allinkl-ftps.yml`
+
+Trigger:
+- push to `main`
+
+What it does:
+1. installs root dependencies
+2. validates required Firebase frontend secrets
+3. builds frontend (`npm run build`)
+4. uploads `dist/` via FTPS to all-inkl
+
+Required GitHub Secrets (deploy workflow):
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_STORAGE_BUCKET`
+- `VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `VITE_FIREBASE_APP_ID`
+- `VITE_DEFAULT_PROPERTY_ID`
+- `VITE_MAIL_API_URL`
+- `ALLINKL_SERVER`
+- `ALLINKL_USER`
+- `ALLINKL_PASS`
+- `ALLINKL_SERVER_DIR`
+
+Important deploy detail:
+- FTPS deploy uploads only `dist/`.
+- `dangerous-clean-slate: false` keeps existing server files untouched (for example `/api`).
+- If `backend-php` changes, upload `/api` files separately.
+
+### Manual production build
+
+```bash
+npm run build
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Upload `dist/` contents to your web root.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Firestore Rules and Indexes
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+- Rules file: `firestore.rules`
+- Index source: `firestore.indexes.json`
+
+Deploy:
+
+```bash
+firebase deploy --only firestore:rules,firestore:indexes
 ```
+
+Current booking overlap paths use indexed server-side queries (no full booking fetch + client filtering).
+
+## PHP API Deployment Notes
+
+If you use the PHP mail flow in production, make sure this exists on server:
+- `/api/send-booking-mail.php`
+- `/api/config.php` (private secrets)
+- `/api/vendor/autoload.php` (from Composer install)
+
+If you update PHP dependencies locally:
+
+```bash
+cd backend-php
+composer install --no-dev --optimize-autoloader
+```
+
+## Troubleshooting
+
+- `Firebase: auth/invalid-api-key`
+  - check all required `VITE_FIREBASE_*` values in the build/runtime env
+- `Konfiguration fehlt: VITE_DEFAULT_PROPERTY_ID`
+  - set `VITE_DEFAULT_PROPERTY_ID`
+- `VITE_MAIL_API_URL ist nicht gesetzt`
+  - set `VITE_MAIL_API_URL` (or ensure `/api/send-booking-mail.php` is reachable)
+- mail endpoint `502`
+  - verify `/api` upload (`send-booking-mail.php`, `config.php`, `vendor/autoload.php`), SMTP credentials, and server logs


### PR DESCRIPTION
## Summary
This PR replaces the default Vite template README with project-specific documentation for the Holiday Apartment app.

## What Changed
- Rewrote `README.md` to document the real project architecture and workflows.
- Added clear local setup instructions for:
  - Frontend (`src/`)
  - Firebase Functions (`functions/`)
  - Optional PHP mail endpoint (`backend-php/`)
- Documented all relevant environment variables and secret handling rules.
- Added CI documentation for current GitHub Actions jobs:
  - Frontend typecheck
  - Frontend lint/build
  - Functions lint/build
- Added branch/PR workflow guidance.
- Added deployment documentation for the FTPS production workflow.
- Added Firestore rules/index deployment notes and booking-overlap index context.
- Added troubleshooting section for common runtime/deploy issues.

## Why
The previous README still contained template content and did not reflect how this repository is actually developed, tested, deployed, and operated.

## Validation
- Documentation reviewed against current repository structure and active workflows:
  - `.github/workflows/ci.yml`
  - `.github/workflows/deploy-allinkl-ftps.yml`
  - `package.json`
  - `functions/package.json`
  - `firebase.json`
  - `src/lib/firebase.ts`
  - `src/lib/db.ts`
  - `backend-php/send-booking-mail.php`

## Result
New team members can now bootstrap the project locally and understand CI/deploy/ops expectations from a single, accurate README.