### PR TITLE
ci: add dedicated Playwright E2E workflow with failure artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,97 @@
+name: E2E
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install (root)
+        run: npm ci
+
+      - name: Validate required frontend env vars
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_DEFAULT_PROPERTY_ID: ${{ secrets.VITE_DEFAULT_PROPERTY_ID }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for v in \
+            VITE_FIREBASE_API_KEY \
+            VITE_FIREBASE_AUTH_DOMAIN \
+            VITE_FIREBASE_PROJECT_ID \
+            VITE_FIREBASE_STORAGE_BUCKET \
+            VITE_FIREBASE_MESSAGING_SENDER_ID \
+            VITE_FIREBASE_APP_ID \
+            VITE_DEFAULT_PROPERTY_ID
+          do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Missing required secret: $v"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        env:
+          CI: "true"
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_DEFAULT_PROPERTY_ID: ${{ secrets.VITE_DEFAULT_PROPERTY_ID }}
+          VITE_MAIL_API_URL: ${{ secrets.VITE_MAIL_API_URL }}
+        run: npm run e2e
+
+      - name: Upload Playwright report (failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload Playwright test results (failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ github.run_id }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Jobs:
 - `Frontend (lint, build)`
 - `Functions (lint, build)`
 
+Dedicated browser-level regression workflow:
+
+- `.github/workflows/e2e.yml`
+  - Job: `E2E (Playwright)`
+  - Uploads `playwright-report/` and `test-results/` as artifacts on failure
+
 Recommended branch workflow:
 1. `git switch main && git pull --ff-only`
 2. `git switch -c <issue-branch>`


### PR DESCRIPTION
## Summary
This PR adds a dedicated Playwright E2E workflow to CI so browser-level regressions are validated separately from lint/build checks.

## What Changed
- Added new workflow: `.github/workflows/e2e.yml`
  - Triggered on `pull_request`, `push` to `main`, and `workflow_dispatch`
  - Separate job: `E2E (Playwright)`
  - Node setup + dependency install (`npm ci`)
  - Installs browser dependencies (`npx playwright install --with-deps chromium`)
  - Runs E2E suite (`npm run e2e`)
  - Adds sensible CI controls:
    - workflow/job concurrency
    - explicit job timeout (`timeout-minutes: 30`)
- Added failure artifact uploads:
  - `playwright-report/`
  - `test-results/`
- Updated `README.md` CI section to document the dedicated E2E workflow and artifact behavior.

## Why
Current CI does not provide browser-level feedback.  
This workflow introduces a clear, independent E2E status check and captures actionable artifacts when failures happen.

## Validation
- `npm run ci` ✅
- `npm run e2e -- --list` ✅
- `npm run e2e -- tests/e2e/public/smoke.spec.ts` ✅ (4 passed)

## Expected Outcome
- CI shows a separate E2E check for each PR.
- On E2E failures, trace/screenshot/video/report artifacts are available for debugging.
- The E2E job can now be added as a required check in branch protection/rulesets.