### PR TITLE
e2e: harden public smoke tests with runtime error checks

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -6,6 +6,7 @@ This folder defines the baseline E2E strategy for the project.
 
 - `public/`:
   - smoke coverage for public routes (`/`, `/gallery`, `/prices`, `/book`)
+  - checks route render + key UI blocks + no uncaught runtime errors (`pageerror` / `console.error`)
 - `booking/`:
   - planned happy-path booking request flow
 - `admin/`:

--- a/tests/e2e/public/smoke.spec.ts
+++ b/tests/e2e/public/smoke.spec.ts
@@ -1,38 +1,116 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+function monitorRuntimeErrors(page: Page) {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+
+  const onPageError = (error: Error) => {
+    pageErrors.push(error.message);
+  };
+  const onConsole = (msg: { type(): string; text(): string }) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  };
+
+  page.on("pageerror", onPageError);
+  page.on("console", onConsole);
+
+  return {
+    pageErrors,
+    consoleErrors,
+    stop: () => {
+      page.off("pageerror", onPageError);
+      page.off("console", onConsole);
+    },
+  };
+}
+
+async function runSmoke(
+  page: Page,
+  route: string,
+  assertPage: (page: Page) => Promise<void>,
+) {
+  const runtime = monitorRuntimeErrors(page);
+  await page.goto(route);
+  await assertPage(page);
+  await page.waitForTimeout(250);
+  runtime.stop();
+
+  expect(
+    runtime.pageErrors,
+    `Unhandled runtime errors detected on route "${route}"`,
+  ).toEqual([]);
+  expect(
+    runtime.consoleErrors,
+    `Console errors detected on route "${route}"`,
+  ).toEqual([]);
+}
 
 test.describe("Public routes smoke", () => {
   test("home page renders navigation", async ({ page }) => {
-    await page.goto("/");
-
-    await expect(
-      page.getByRole("link", { name: "Antjes Ankerplatz" }),
-    ).toBeVisible();
-    await expect(page.getByRole("link", { name: "Galerie" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Preise" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Buchen" })).toBeVisible();
+    await runSmoke(page, "/", async (activePage) => {
+      await expect(
+        activePage.getByRole("link", { name: "Antjes Ankerplatz" }),
+      ).toBeVisible();
+      await expect(activePage.getByRole("link", { name: "Galerie" })).toBeVisible();
+      await expect(activePage.getByRole("link", { name: "Preise" })).toBeVisible();
+      await expect(activePage.getByRole("link", { name: "Buchen" })).toBeVisible();
+      await expect(
+        activePage.getByRole("heading", {
+          level: 1,
+          name: "Ferienwohnung Antjes Ankerplatz",
+        }),
+      ).toBeVisible();
+      await expect(
+        activePage.getByRole("button", { name: "Verfügbarkeit prüfen" }),
+      ).toBeVisible();
+      await expect(
+        activePage.getByRole("heading", { level: 2, name: "Wohnungsbeschreibung" }),
+      ).toBeVisible();
+    });
   });
 
   test("gallery page renders heading", async ({ page }) => {
-    await page.goto("/gallery");
-    await expect(
-      page.getByRole("heading", { level: 1, name: "Galerie" }),
-    ).toBeVisible();
+    await runSmoke(page, "/gallery", async (activePage) => {
+      await expect(
+        activePage.getByRole("heading", { level: 1, name: "Galerie" }),
+      ).toBeVisible();
+      await expect(activePage.getByText("Klick auf ein Bild")).toBeVisible();
+      await expect(
+        activePage
+          .getByRole("button", { name: /^Ferienwohnung Ansicht/ })
+          .first(),
+      ).toBeVisible();
+    });
   });
 
   test("prices page renders heading", async ({ page }) => {
-    await page.goto("/prices");
-    await expect(page.getByRole("heading", { level: 1 })).toContainText(
-      "Preise",
-    );
+    await runSmoke(page, "/prices", async (activePage) => {
+      await expect(activePage.getByRole("heading", { level: 1 })).toContainText(
+        "Preise",
+      );
+      await expect(
+        activePage.getByRole("heading", { level: 2, name: "Saisonpreise" }),
+      ).toBeVisible();
+      await expect(
+        activePage.getByRole("link", { name: "Jetzt Verfügbarkeit prüfen" }),
+      ).toBeVisible();
+    });
   });
 
   test("booking page renders CTA", async ({ page }) => {
-    await page.goto("/book");
-    await expect(page.getByRole("heading", { level: 1 })).toContainText(
-      "Buchen",
-    );
-    await expect(
-      page.getByRole("button", { name: "Anfrage senden" }),
-    ).toBeVisible();
+    await runSmoke(page, "/book", async (activePage) => {
+      await expect(activePage.getByRole("heading", { level: 1 })).toContainText(
+        "Buchen",
+      );
+      await expect(activePage.getByText("Zeitraum wählen")).toBeVisible();
+      await expect(activePage.getByText("Name")).toBeVisible();
+      await expect(activePage.getByText("E-Mail")).toBeVisible();
+      await expect(activePage.locator("#booking-form")).toBeVisible();
+      await expect(
+        activePage.getByRole("button", { name: "Anfrage senden" }),
+      ).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR strengthens the public E2E smoke suite to better catch route and rendering regressions across key public pages.

## Scope
Covered routes:
- `/`
- `/gallery`
- `/prices`
- `/book`

## What Changed
- Refactored `tests/e2e/public/smoke.spec.ts` to use a shared smoke helper.
- Added runtime stability checks on every route:
  - fail on uncaught `pageerror`
  - fail on `console.error`
- Expanded route assertions to verify key visible UI elements per page:
  - Home: navigation, main headline, CTA, primary content block
  - Gallery: page heading, intro copy, at least one gallery item
  - Prices: heading, season section, booking CTA
  - Booking: heading, form presence, core fields, submit CTA
- Updated `tests/e2e/README.md` to document smoke policy:
  - route render + key UI blocks + no runtime errors

## Why
A minimal smoke check existed, but it was too shallow for reliable regression detection.  
This update makes the suite deterministic and much more effective at catching browser-level breakages in core public routes.

## Validation
- `npm run e2e -- tests/e2e/public/smoke.spec.ts` ✅ (4 passed)
- `npm run e2e -- --list` ✅

## Result
Public route regressions (render failures, missing critical UI, runtime JS errors) are now detected earlier and more reliably in local and CI E2E runs.