### PR TITLE
Add DE/EN language switch and i18n MVP for public pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { NavBar } from "./components/NavBar";
 import { AppRoutes } from "./app/routes";
 import { useLocation } from "react-router-dom";
+import { useT } from "./i18n/useLanguage";
 
 export default function App() {
+  const t = useT();
   const { pathname } = useLocation();
   const isBookingPage = pathname.startsWith("/book");
 
@@ -17,8 +19,8 @@ export default function App() {
         <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 py-6 text-sm text-[color:var(--color-muted)]">
           <div>© {new Date().getFullYear()} Antjes Ankerplatz</div>
           <nav className="space-x-4">
-            <a href="/impressum" className="hover:underline">Impressum</a>
-            <a href="/datenschutz" className="hover:underline">Datenschutz</a>
+            <a href="/impressum" className="hover:underline">{t("app.footer.imprint")}</a>
+            <a href="/datenschutz" className="hover:underline">{t("app.footer.privacy")}</a>
           </nav>
         </div>
       </footer>
@@ -29,13 +31,13 @@ export default function App() {
             onClick={() => location.assign("/book")}
             className="air-btn-primary w-full"
           >
-            Jetzt buchen
+            {t("app.footer.bookNow")}
           </button>
         )}
         <div className="mt-2 text-center text-xs text-[color:var(--color-muted)]">
-          <a href="/impressum" className="mx-2 underline">Impressum</a>
+          <a href="/impressum" className="mx-2 underline">{t("app.footer.imprint")}</a>
           <span aria-hidden>·</span>
-          <a href="/datenschutz" className="mx-2 underline">Datenschutz</a>
+          <a href="/datenschutz" className="mx-2 underline">{t("app.footer.privacy")}</a>
         </div>
       </footer>
     </div>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from "react";
 import { Routes, Route } from "react-router-dom";
+import { useT } from "../i18n/useLanguage";
 
 const Home = lazy(() => import("../pages/Home"));
 const Gallery = lazy(() => import("../pages/Gallery"));
@@ -13,7 +14,8 @@ const Imprint = lazy(() => import("../pages/Imprint"));
 const Privacy = lazy(() => import("../pages/Privacy"));
 
 function RouteLoading() {
-  return <div className="p-4 text-slate-600">Laden …</div>;
+  const t = useT();
+  return <div className="p-4 text-slate-600">{t("routes.loading")}</div>;
 }
 
 export function AppRoutes() {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,21 +1,62 @@
 import { Link, NavLink } from "react-router-dom";
+import { useLanguage, useT } from "../i18n/useLanguage";
 
 export function NavBar() {
+  const { language, setLanguage } = useLanguage();
+  const t = useT();
+
   return (
     <header className="sticky top-0 z-50 border-b border-[color:var(--color-hairline)] bg-white/95 backdrop-blur-sm">
       <div className="mx-auto max-w-[1280px] px-4 md:px-8">
-        <div className="flex w-full flex-col gap-2 py-2 sm:h-20 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:py-0">
-          <Link
-            to="/"
-            className="air-focus-ring shrink-0 rounded-full px-2 py-1 text-sm font-semibold leading-none text-[color:var(--color-ink)] sm:text-base"
+        <div className="w-full py-2 sm:py-3">
+          <div className="flex items-center justify-between gap-3">
+            <Link
+              to="/"
+              className="air-focus-ring shrink-0 rounded-full px-2 py-1 text-sm font-semibold leading-none text-[color:var(--color-ink)] sm:text-base"
+            >
+              {t("nav.brand")}
+            </Link>
+            <div
+              className="inline-flex items-center rounded-full border border-[color:var(--color-hairline)] bg-white p-1"
+              role="group"
+              aria-label={t("nav.languageLabel")}
+            >
+              <button
+                type="button"
+                className={[
+                  "air-focus-ring rounded-full px-3 py-1 text-xs font-semibold transition",
+                  language === "de"
+                    ? "bg-[color:var(--color-primary)] text-white"
+                    : "text-[color:var(--color-ink)] hover:bg-[color:var(--color-surface-soft)]",
+                ].join(" ")}
+                onClick={() => setLanguage("de")}
+                aria-pressed={language === "de"}
+              >
+                {t("nav.languageDe")}
+              </button>
+              <button
+                type="button"
+                className={[
+                  "air-focus-ring rounded-full px-3 py-1 text-xs font-semibold transition",
+                  language === "en"
+                    ? "bg-[color:var(--color-primary)] text-white"
+                    : "text-[color:var(--color-ink)] hover:bg-[color:var(--color-surface-soft)]",
+                ].join(" ")}
+                onClick={() => setLanguage("en")}
+                aria-pressed={language === "en"}
+              >
+                {t("nav.languageEn")}
+              </button>
+            </div>
+          </div>
+          <nav
+            className="mt-2 grid w-full grid-cols-3 gap-2 text-sm sm:w-auto sm:grid-flow-col sm:justify-start sm:gap-2 sm:text-base"
+            aria-label={t("nav.ariaMain")}
           >
-            Antjes Ankerplatz
-          </Link>
-          <nav className="grid w-full grid-cols-3 gap-2 text-sm sm:w-auto sm:grid-cols-none sm:grid-flow-col sm:items-center" aria-label="Hauptnavigation">
             {[
-              { to: "/gallery", label: "Galerie" },
-              { to: "/prices", label: "Preise" },
-              { to: "/book", label: "Buchen" },
+              { to: "/gallery", label: t("nav.gallery") },
+              { to: "/prices", label: t("nav.prices") },
+              { to: "/book", label: t("nav.book") },
             ].map(({ to, label }) => (
               <NavLink
                 key={to}

--- a/src/i18n/LanguageProvider.tsx
+++ b/src/i18n/LanguageProvider.tsx
@@ -1,0 +1,97 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { de as dateFnsDe, enUS } from "date-fns/locale";
+import { de, en, type Language } from "./translations";
+import {
+  LanguageContext,
+  type LanguageContextValue,
+  type TranslationParams,
+} from "./context";
+
+const STORAGE_KEY = "ferienwohnung.language";
+const DEFAULT_LANGUAGE: Language = "de";
+
+const dictionaries = {
+  de,
+  en,
+};
+
+function normalizeLanguage(input: unknown): Language {
+  return input === "en" ? "en" : "de";
+}
+
+function getInitialLanguage(): Language {
+  if (typeof window === "undefined") {
+    return DEFAULT_LANGUAGE;
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    return normalizeLanguage(stored);
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+function interpolate(template: string, params?: TranslationParams): string {
+  if (!params) {
+    return template;
+  }
+
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => {
+    const value = params[key];
+    return value === undefined ? `{${key}}` : String(value);
+  });
+}
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(() => getInitialLanguage());
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, language);
+    }
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const setLanguage = useCallback((next: Language) => {
+    setLanguageState(normalizeLanguage(next));
+  }, []);
+
+  const t = useCallback(
+    (key: string, params?: TranslationParams): string => {
+      const dict = dictionaries[language];
+      const fallback = dictionaries.de;
+      const entry = dict[key] ?? fallback[key];
+
+      if (!entry) {
+        return key;
+      }
+
+      if (typeof entry === "function") {
+        return entry(params ?? {});
+      }
+
+      return interpolate(entry, params);
+    },
+    [language],
+  );
+
+  const value = useMemo<LanguageContextValue>(
+    () => ({
+      language,
+      setLanguage,
+      locale: language === "de" ? "de-DE" : "en-US",
+      dateFnsLocale: language === "de" ? dateFnsDe : enUS,
+      t,
+    }),
+    [language, setLanguage, t],
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}

--- a/src/i18n/context.ts
+++ b/src/i18n/context.ts
@@ -1,0 +1,15 @@
+import { createContext } from "react";
+import type { Locale } from "date-fns";
+import type { Language } from "./translations";
+
+export type TranslationParams = Record<string, string | number>;
+
+export type LanguageContextValue = {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  locale: "de-DE" | "en-US";
+  dateFnsLocale: Locale;
+  t: (key: string, params?: TranslationParams) => string;
+};
+
+export const LanguageContext = createContext<LanguageContextValue | null>(null);

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,363 @@
+export type Language = "de" | "en";
+
+type TranslationParams = Record<string, string | number>;
+type TranslationEntry = string | ((params: TranslationParams) => string);
+
+export type TranslationDictionary = Record<string, TranslationEntry>;
+
+export const de: TranslationDictionary = {
+  "nav.brand": "Antjes Ankerplatz",
+  "nav.ariaMain": "Hauptnavigation",
+  "nav.gallery": "Galerie",
+  "nav.prices": "Preise",
+  "nav.book": "Buchen",
+  "nav.languageLabel": "Sprache",
+  "nav.languageDe": "DE",
+  "nav.languageEn": "EN",
+
+  "app.footer.bookNow": "Jetzt buchen",
+  "app.footer.imprint": "Impressum",
+  "app.footer.privacy": "Datenschutz",
+
+  "routes.loading": "Laden …",
+
+  "home.heroAlt": "Meerblick",
+  "home.title": "Ferienwohnung Antjes Ankerplatz",
+  "home.subtitle":
+    "Maritimer Komfort, 2000 m bis zur Nordsee – jetzt Verfügbarkeit prüfen.",
+  "home.arrival": "Anreise",
+  "home.departure": "Abreise",
+  "home.guests": "Gäste",
+  "home.checkAvailability": "Verfügbarkeit prüfen",
+  "home.featuresTitle": "Ausstattungsmerkmale",
+  "home.featureBeach": "Strandnah",
+  "home.featureBeachDesc": "20 Minuten zu Fuß",
+  "home.featureParking": "Kostenloses Parken",
+  "home.featureParkingDesc": "Privatstellplatz",
+  "home.featurePets": "Haustiere erlaubt",
+  "home.featurePetsDesc": "auf Anfrage",
+  "home.featureWifi": "WLAN & Smart-TV",
+  "home.featureWifiDesc": "inklusive",
+  "home.descriptionTitle": "Wohnungsbeschreibung",
+  "home.descriptionP1":
+    "Antjes Ankerplatz ist eine gemütliche, maritime Ferienwohnung für entspannte Tage an der Nordsee. Die Wohnung bietet einen hellen Wohnbereich, eine gut ausgestattete Küche und komfortable Schlafmöglichkeiten für Paare und Familien.",
+  "home.descriptionP2":
+    "Dank der strandnahen Lage, eigenem Stellplatz und kurzer Wege zu Einkaufsmöglichkeiten ist sie ein idealer Ausgangspunkt für Erholung, Spaziergänge und Ausflüge rund um Cuxhaven.",
+  "home.galleryTitle": "Bildergalerie",
+  "home.galleryHint":
+    "Die Bilder laufen automatisch von rechts nach links durch.",
+  "home.galleryAlt": ({ index }: TranslationParams) =>
+    `Ferienwohnung Ansicht ${index}`,
+  "home.galleryCount": ({ current, total }: TranslationParams) =>
+    `Bild ${current} von ${total}`,
+
+  "gallery.title": "Galerie",
+  "gallery.intro":
+    "Klick auf ein Bild für die große Ansicht. Mit den Pfeiltasten kannst du durchblättern.",
+  "gallery.imageAlt": ({ index }: TranslationParams) =>
+    `Ferienwohnung Ansicht ${index}`,
+  "gallery.lightboxTitle": "Große Bildansicht",
+  "gallery.close": "Schließen",
+  "gallery.prev": "Vorheriges Bild",
+  "gallery.next": "Nächstes Bild",
+  "gallery.count": ({ current, total }: TranslationParams) =>
+    `Bild ${current} von ${total}`,
+
+  "prices.defaultPropertyName": "Ferienwohnung",
+  "prices.title": ({ propertyName }: TranslationParams) => `${propertyName} – Preise`,
+  "prices.subtitle":
+    "Transparente Saisonpreise & Standardpreis. Endreinigung und Kurtaxe separat wie angegeben.",
+  "prices.standardTitle": "Standardpreis außerhalb von Saisons",
+  "prices.perNight": "/ Nacht",
+  "prices.standardHint": "Gilt für Nächte, die in keine definierte Saison fallen.",
+  "prices.cleaningTitle": "Endreinigung",
+  "prices.cleaningHint":
+    "Einmalig pro Aufenthalt. Kurtaxe nach lokaler Satzung ggf. zusätzlich.",
+  "prices.seasonsTitle": "Saisonpreise",
+  "prices.loading": "Laden …",
+  "prices.errorLoad": "Preise konnten nicht geladen werden.",
+  "prices.empty": "Noch keine Saisons erfasst.",
+  "prices.caption": ({ propertyName }: TranslationParams) =>
+    `Saisonpreise für ${propertyName} mit Zeitraum, Tarifname, Preis pro Nacht und Mindestnächten`,
+  "prices.colRange": "Zeitraum",
+  "prices.colName": "Name",
+  "prices.colRate": "Preis/Nacht",
+  "prices.colMinNights": "Min. Nächte",
+  "prices.rangeEndExclusive": "(Ende exkl.)",
+  "prices.ctaTitle": "Fragen zum Zeitraum oder Preis?",
+  "prices.ctaText":
+    "Prüfe die Verfügbarkeit und erhalte den Gesamtpreis direkt im nächsten Schritt.",
+  "prices.ctaButton": "Jetzt Verfügbarkeit prüfen",
+
+  "booking.defaultPropertyName": "Ferienwohnung",
+  "booking.loadError": "Daten konnten nicht geladen werden.",
+  "booking.noProperty":
+    "Keine Unterkunft gefunden. Bitte zuerst Stammdaten im Adminbereich anlegen.",
+  "booking.propertyLoadError": "Unterkunft konnte nicht geladen werden.",
+  "booking.invalidRange": "Bitte zuerst einen gültigen Zeitraum auswählen.",
+  "booking.rangeUnavailable": "Der gewählte Zeitraum ist aktuell nicht verfügbar.",
+  "booking.requiredNameEmail": "Bitte Name und E-Mail angeben.",
+  "booking.requiredAddress": "Bitte Straße, PLZ und Ort angeben.",
+  "booking.requiredValidEmail": "Bitte eine gültige E-Mail angeben.",
+  "booking.submitSuccess":
+    "Vielen Dank! Deine Anfrage wurde übermittelt und die Bestätigungsmail wurde versendet.",
+  "booking.submitMailFailed": ({ reason }: TranslationParams) =>
+    `Anfrage gespeichert, aber Mailversand fehlgeschlagen (${reason || "unbekannter Fehler"}).`,
+  "booking.submitError": "Anfrage konnte nicht gesendet werden.",
+  "booking.rateLabelStandard": "Standard",
+  "booking.heading": ({ propertyName }: TranslationParams) =>
+    `Buchen – ${propertyName}`,
+  "booking.subheading":
+    "Wähle Zeitraum & Gäste. Der Preis wird live berechnet (inkl. Endreinigung & Kurtaxe ab 16 Jahren).",
+  "booking.fieldDateRange": "Zeitraum wählen",
+  "booking.fieldAdults": "Erwachsene (≥16)",
+  "booking.fieldChildren": "Kinder (0–15)",
+  "booking.fieldName": "Name",
+  "booking.placeholderName": "Vor- und Nachname",
+  "booking.fieldEmail": "E-Mail",
+  "booking.fieldPhoneOptional": "Telefon (optional)",
+  "booking.fieldStreet": "Straße & Nr.",
+  "booking.placeholderStreet": "z. B. Spangerstraße 9",
+  "booking.fieldZip": "PLZ",
+  "booking.fieldCity": "Ort",
+  "booking.placeholderCity": "Cuxhaven",
+  "booking.fieldCountry": "Land",
+  "booking.placeholderCountry": "Deutschland",
+  "booking.fieldMessageOptional": "Nachricht (optional)",
+  "booking.placeholderMessage": "z.B. Ankunftszeit, Fragen …",
+  "booking.loading": "Laden …",
+  "booking.invalidNightCount":
+    "Bitte ein gültiges Datum wählen (mindestens eine Nacht).",
+  "booking.summaryTitle": "Zusammenfassung",
+  "booking.summaryNights": "Nächte",
+  "booking.summaryStays": "Übernachtungen",
+  "booking.summaryCleaning": "Endreinigung",
+  "booking.summaryTax": "Kurtaxe (Erwachsene)",
+  "booking.summaryTotal": "Gesamt",
+  "booking.summaryHint":
+    "Kurtaxe ab 16 Jahren. Saisonpreise inkl. USt., Kurtaxe nach Ortsrecht.",
+  "booking.notesTitle": "Hinweise",
+  "booking.noteEndExclusive": "Ende exkl.: Die Abreise-Nacht ist nicht berechnet.",
+  "booking.noteSeasonRates":
+    "In definierten Saisons gilt der jeweilige Nachtpreis. Außerhalb gilt der Standardpreis.",
+  "booking.noteTax":
+    "Kurtaxe je Nacht pro zahlender Person (≥16) gemäß Kurtaxe-Band.",
+  "booking.nightlyDetails": "Preis je Nacht anzeigen",
+  "booking.nightlyCaption":
+    "Preisaufschlüsselung pro Nacht für den ausgewählten Zeitraum inklusive Tarif, Kurtaxe und Gesamtsumme",
+  "booking.colDate": "Datum",
+  "booking.colRateType": "Tarif",
+  "booking.colRatePerNight": "Preis / Nacht",
+  "booking.colTaxPerNight": "Kurtaxe / Nacht",
+  "booking.colTotalPerNight": "Summe / Nacht",
+  "booking.rowStayTotal": "Summe Übernachtungen",
+  "booking.rowCleaning": "Endreinigung",
+  "booking.rowTaxTotal": "Kurtaxe (gesamt)",
+  "booking.rowGrandTotal": "Gesamt",
+  "booking.priceCalcError": "Preis konnte nicht berechnet werden.",
+  "booking.availabilityChecking": "Verfügbarkeit wird geprüft …",
+  "booking.availabilityAvailable": "Zeitraum ist aktuell verfügbar.",
+  "booking.availabilityUnavailable": "Zeitraum ist leider bereits belegt.",
+  "booking.minStay": ({ nights }: TranslationParams) =>
+    `Mindestaufenthalt: ${nights} Nächte.`,
+  "booking.submitSending": "Sende …",
+  "booking.submit": "Anfrage senden",
+  "booking.closeNotice": "Hinweis schließen",
+
+  "login.errorLogin": "Login fehlgeschlagen.",
+  "login.successRegister": "Konto angelegt. Du bist jetzt angemeldet.",
+  "login.errorRegister": "Registrierung fehlgeschlagen.",
+  "login.resetNeedEmail": "Bitte E-Mail eingeben, um einen Reset-Link zu erhalten.",
+  "login.resetSent": "Passwort-Reset gesendet. Bitte Posteingang prüfen.",
+  "login.resetError": "Reset fehlgeschlagen.",
+  "login.adminTitle": "Admin",
+  "login.loggedInAs": ({ email }: TranslationParams) => `Angemeldet als ${email}`,
+  "login.logout": "Logout",
+  "login.titleLogin": "Anmelden",
+  "login.titleRegister": "Registrieren",
+  "login.email": "E-Mail",
+  "login.password": "Passwort",
+  "login.forgot": "Passwort vergessen?",
+  "login.noAccount": "Kein Konto?",
+  "login.registerNow": "Jetzt registrieren",
+  "login.hasAccount": "Schon ein Konto?",
+  "login.toLogin": "Zum Login",
+};
+
+export const en: TranslationDictionary = {
+  "nav.brand": "Antjes Ankerplatz",
+  "nav.ariaMain": "Main navigation",
+  "nav.gallery": "Gallery",
+  "nav.prices": "Prices",
+  "nav.book": "Book",
+  "nav.languageLabel": "Language",
+  "nav.languageDe": "DE",
+  "nav.languageEn": "EN",
+
+  "app.footer.bookNow": "Book now",
+  "app.footer.imprint": "Legal notice",
+  "app.footer.privacy": "Privacy",
+
+  "routes.loading": "Loading …",
+
+  "home.heroAlt": "Sea view",
+  "home.title": "Holiday Apartment Antjes Ankerplatz",
+  "home.subtitle":
+    "Maritime comfort, 2000 m to the North Sea - check availability now.",
+  "home.arrival": "Arrival",
+  "home.departure": "Departure",
+  "home.guests": "Guests",
+  "home.checkAvailability": "Check availability",
+  "home.featuresTitle": "Amenities",
+  "home.featureBeach": "Near the beach",
+  "home.featureBeachDesc": "20 minutes on foot",
+  "home.featureParking": "Free parking",
+  "home.featureParkingDesc": "Private parking space",
+  "home.featurePets": "Pets allowed",
+  "home.featurePetsDesc": "on request",
+  "home.featureWifi": "Wi-Fi & Smart TV",
+  "home.featureWifiDesc": "included",
+  "home.descriptionTitle": "Apartment description",
+  "home.descriptionP1":
+    "Antjes Ankerplatz is a cozy maritime holiday apartment for relaxing days at the North Sea. The apartment offers a bright living area, a well-equipped kitchen, and comfortable sleeping arrangements for couples and families.",
+  "home.descriptionP2":
+    "Thanks to its beachside location, private parking, and short distances to shopping options, it is an ideal base for recreation, walks, and trips around Cuxhaven.",
+  "home.galleryTitle": "Photo gallery",
+  "home.galleryHint":
+    "Images automatically slide from right to left.",
+  "home.galleryAlt": ({ index }: TranslationParams) =>
+    `Holiday apartment view ${index}`,
+  "home.galleryCount": ({ current, total }: TranslationParams) =>
+    `Image ${current} of ${total}`,
+
+  "gallery.title": "Gallery",
+  "gallery.intro":
+    "Click an image for a larger view. Use the arrow keys to browse.",
+  "gallery.imageAlt": ({ index }: TranslationParams) =>
+    `Holiday apartment view ${index}`,
+  "gallery.lightboxTitle": "Large image view",
+  "gallery.close": "Close",
+  "gallery.prev": "Previous image",
+  "gallery.next": "Next image",
+  "gallery.count": ({ current, total }: TranslationParams) =>
+    `Image ${current} of ${total}`,
+
+  "prices.defaultPropertyName": "Holiday apartment",
+  "prices.title": ({ propertyName }: TranslationParams) => `${propertyName} - Prices`,
+  "prices.subtitle":
+    "Transparent seasonal prices and standard rate. Final cleaning and tourist tax are listed separately.",
+  "prices.standardTitle": "Standard price outside seasons",
+  "prices.perNight": "/ night",
+  "prices.standardHint": "Applies to nights not covered by a defined season.",
+  "prices.cleaningTitle": "Final cleaning",
+  "prices.cleaningHint":
+    "One-time fee per stay. Tourist tax may apply according to local regulations.",
+  "prices.seasonsTitle": "Seasonal prices",
+  "prices.loading": "Loading …",
+  "prices.errorLoad": "Prices could not be loaded.",
+  "prices.empty": "No seasons configured yet.",
+  "prices.caption": ({ propertyName }: TranslationParams) =>
+    `Seasonal prices for ${propertyName} with date range, rate name, price per night, and minimum nights`,
+  "prices.colRange": "Date range",
+  "prices.colName": "Name",
+  "prices.colRate": "Price/night",
+  "prices.colMinNights": "Min. nights",
+  "prices.rangeEndExclusive": "(end excl.)",
+  "prices.ctaTitle": "Questions about dates or price?",
+  "prices.ctaText":
+    "Check availability and get the total price in the next step.",
+  "prices.ctaButton": "Check availability now",
+
+  "booking.defaultPropertyName": "Holiday apartment",
+  "booking.loadError": "Data could not be loaded.",
+  "booking.noProperty":
+    "No accommodation found. Please create the property data in admin first.",
+  "booking.propertyLoadError": "Accommodation could not be loaded.",
+  "booking.invalidRange": "Please select a valid date range first.",
+  "booking.rangeUnavailable": "The selected period is currently unavailable.",
+  "booking.requiredNameEmail": "Please enter name and email.",
+  "booking.requiredAddress": "Please enter street, ZIP code, and city.",
+  "booking.requiredValidEmail": "Please enter a valid email address.",
+  "booking.submitSuccess":
+    "Thank you. Your request has been submitted and the confirmation email has been sent.",
+  "booking.submitMailFailed": ({ reason }: TranslationParams) =>
+    `Request saved, but sending email failed (${reason || "unknown error"}).`,
+  "booking.submitError": "Request could not be sent.",
+  "booking.rateLabelStandard": "Standard",
+  "booking.heading": ({ propertyName }: TranslationParams) =>
+    `Book - ${propertyName}`,
+  "booking.subheading":
+    "Choose period and guests. Price is calculated live (including final cleaning and tourist tax from age 16).",
+  "booking.fieldDateRange": "Select date range",
+  "booking.fieldAdults": "Adults (>=16)",
+  "booking.fieldChildren": "Children (0-15)",
+  "booking.fieldName": "Name",
+  "booking.placeholderName": "First and last name",
+  "booking.fieldEmail": "Email",
+  "booking.fieldPhoneOptional": "Phone (optional)",
+  "booking.fieldStreet": "Street & No.",
+  "booking.placeholderStreet": "e.g. Spangerstrasse 9",
+  "booking.fieldZip": "ZIP code",
+  "booking.fieldCity": "City",
+  "booking.placeholderCity": "Cuxhaven",
+  "booking.fieldCountry": "Country",
+  "booking.placeholderCountry": "Germany",
+  "booking.fieldMessageOptional": "Message (optional)",
+  "booking.placeholderMessage": "e.g. arrival time, questions ...",
+  "booking.loading": "Loading …",
+  "booking.invalidNightCount": "Please select valid dates (at least one night).",
+  "booking.summaryTitle": "Summary",
+  "booking.summaryNights": "Nights",
+  "booking.summaryStays": "Overnight stays",
+  "booking.summaryCleaning": "Final cleaning",
+  "booking.summaryTax": "Tourist tax (adults)",
+  "booking.summaryTotal": "Total",
+  "booking.summaryHint":
+    "Tourist tax applies from age 16. Seasonal prices include VAT, tourist tax according to local regulations.",
+  "booking.notesTitle": "Notes",
+  "booking.noteEndExclusive": "End excl.: Departure night is not charged.",
+  "booking.noteSeasonRates":
+    "Defined seasons use the corresponding nightly rate. Outside seasons, the standard rate applies.",
+  "booking.noteTax":
+    "Tourist tax is charged per night per paying person (>=16), depending on the tax band.",
+  "booking.nightlyDetails": "Show nightly breakdown",
+  "booking.nightlyCaption":
+    "Nightly price breakdown for the selected period including rate, tourist tax, and total",
+  "booking.colDate": "Date",
+  "booking.colRateType": "Rate",
+  "booking.colRatePerNight": "Price / night",
+  "booking.colTaxPerNight": "Tourist tax / night",
+  "booking.colTotalPerNight": "Total / night",
+  "booking.rowStayTotal": "Total overnight stays",
+  "booking.rowCleaning": "Final cleaning",
+  "booking.rowTaxTotal": "Tourist tax (total)",
+  "booking.rowGrandTotal": "Total",
+  "booking.priceCalcError": "Price could not be calculated.",
+  "booking.availabilityChecking": "Checking availability …",
+  "booking.availabilityAvailable": "The period is currently available.",
+  "booking.availabilityUnavailable": "Unfortunately, the period is already booked.",
+  "booking.minStay": ({ nights }: TranslationParams) =>
+    `Minimum stay: ${nights} nights.`,
+  "booking.submitSending": "Sending …",
+  "booking.submit": "Send request",
+  "booking.closeNotice": "Close notice",
+
+  "login.errorLogin": "Login failed.",
+  "login.successRegister": "Account created. You are now signed in.",
+  "login.errorRegister": "Registration failed.",
+  "login.resetNeedEmail": "Please enter your email to receive a reset link.",
+  "login.resetSent": "Password reset sent. Please check your inbox.",
+  "login.resetError": "Reset failed.",
+  "login.adminTitle": "Admin",
+  "login.loggedInAs": ({ email }: TranslationParams) => `Signed in as ${email}`,
+  "login.logout": "Logout",
+  "login.titleLogin": "Sign in",
+  "login.titleRegister": "Register",
+  "login.email": "Email",
+  "login.password": "Password",
+  "login.forgot": "Forgot password?",
+  "login.noAccount": "No account?",
+  "login.registerNow": "Register now",
+  "login.hasAccount": "Already have an account?",
+  "login.toLogin": "Go to sign in",
+};

--- a/src/i18n/useLanguage.ts
+++ b/src/i18n/useLanguage.ts
@@ -1,0 +1,14 @@
+import { useContext } from "react";
+import { LanguageContext } from "./context";
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within LanguageProvider");
+  }
+  return context;
+}
+
+export function useT() {
+  return useLanguage().t;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -42,6 +42,7 @@ async function sendAdminActionMail(
         adults: booking.adults,
         children: booking.children,
         contact: booking.contact,
+        language: booking.contact.language ?? "de",
         message: booking.message ?? "",
         status: booking.status,
         propertyName,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -93,6 +93,7 @@ export const BookingSchema = z.object({
     name: z.string().min(1),
     email: z.string().email(),
     phone: z.string().optional().default(""),
+    language: z.enum(["de", "en"]).optional().default("de"),
     address: AddressSchema.optional().default({}),
   }),
   message: z.string().optional().default(""),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
+import { LanguageProvider } from './i18n/LanguageProvider';
 import './index.css';
 
 const qc = new QueryClient();
@@ -10,9 +11,11 @@ const qc = new QueryClient();
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <LanguageProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </LanguageProvider>
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -13,8 +13,8 @@ import type { Property, Season, TouristTaxBand } from "../lib/schemas";
 import { priceForStay, touristTaxForStay } from "../lib/pricing";
 import { DayPicker } from "react-day-picker";
 import type { DateRange } from "react-day-picker";
-import { de } from "date-fns/locale";
 import "react-day-picker/dist/style.css";
+import { useLanguage, useT } from "../i18n/useLanguage";
 
 // Format a JS Date to YYYY-MM-DD in **local** time (no UTC shift)
 function formatLocalISO(date: Date): string {
@@ -25,11 +25,13 @@ function formatLocalISO(date: Date): string {
 }
 
 export default function Booking() {
+  const { language, locale, dateFnsLocale } = useLanguage();
+  const t = useT();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const [propertyId, setPropertyId] = useState<string | null>(null);
-  const [propertyName, setPropertyName] = useState<string>("Ferienwohnung");
+  const [propertyName, setPropertyName] = useState<string>(t("booking.defaultPropertyName"));
   const [currency, setCurrency] = useState<string>("EUR");
   const [defaultRate, setDefaultRate] = useState<number>(0);
   const [cleaningFee, setCleaningFee] = useState<number>(0);
@@ -63,7 +65,9 @@ export default function Booking() {
   const [street, setStreet] = useState<string>("");
   const [zip, setZip] = useState<string>("");
   const [city, setCity] = useState<string>("");
-  const [country, setCountry] = useState<string>("Deutschland");
+  const [country, setCountry] = useState<string>(
+    language === "de" ? "Deutschland" : "Germany",
+  );
 
   // Submit-Status
   const [submitting, setSubmitting] = useState(false);
@@ -125,7 +129,7 @@ export default function Booking() {
         if (!resolvedPropertyId || !propertyData) {
           const firstProperty = await getFirstProperty();
           if (!firstProperty) {
-            throw new Error("Keine Unterkunft gefunden. Bitte zuerst Stammdaten im Adminbereich anlegen.");
+            throw new Error(t("booking.noProperty"));
           }
           resolvedPropertyId = firstProperty.id;
           propertyData = firstProperty.data;
@@ -149,11 +153,11 @@ export default function Booking() {
         }
 
         if (!resolvedPropertyId || !propertyData) {
-          throw new Error("Unterkunft konnte nicht geladen werden.");
+          throw new Error(t("booking.propertyLoadError"));
         }
 
         setPropertyId(resolvedPropertyId);
-        setPropertyName(propertyData.name || "Ferienwohnung");
+        setPropertyName(propertyData.name || t("booking.defaultPropertyName"));
         setCurrency(propertyData.currency || "EUR");
         setDefaultRate(propertyData.defaultNightlyRate ?? 0);
         setCleaningFee(propertyData.cleaningFee ?? 0);
@@ -166,12 +170,12 @@ export default function Booking() {
         console.debug("[booking] init – done]");
       } catch (e) {
         console.error("[booking] init FAILED", e);
-        setError(e instanceof Error ? e.message : "Daten konnten nicht geladen werden.");
+        setError(e instanceof Error ? e.message : t("booking.loadError"));
       } finally {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (range?.from) setStart(formatLocalISO(range.from));
@@ -202,7 +206,24 @@ export default function Booking() {
     })();
   }, [propertyId]);
 
-  const fmt = useMemo(() => new Intl.NumberFormat("de-DE", { style: "currency", currency }), [currency]);
+  useEffect(() => {
+    setCountry((previous) => {
+      const trimmed = previous.trim();
+      if (
+        trimmed === "" ||
+        trimmed === "Deutschland" ||
+        trimmed === "Germany"
+      ) {
+        return language === "de" ? "Deutschland" : "Germany";
+      }
+      return previous;
+    });
+  }, [language]);
+
+  const fmt = useMemo(
+    () => new Intl.NumberFormat(locale, { style: "currency", currency }),
+    [currency, locale],
+  );
 
   const calc = useMemo(() => {
     try {
@@ -264,22 +285,22 @@ export default function Booking() {
   async function submitRequest(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!propertyId || !calc) {
-      flash({ type: "error", text: "Bitte zuerst einen gültigen Zeitraum auswählen." });
+      flash({ type: "error", text: t("booking.invalidRange") });
       return;
     }
     if (avail !== "available") {
-      flash({ type: "error", text: "Der gewählte Zeitraum ist aktuell nicht verfügbar." });
+      flash({ type: "error", text: t("booking.rangeUnavailable") });
       return;
     }
     setSubmitting(true);
     console.log("[booking] submit →", { propertyId, start, end, adults, children, name, email });
     try {
       if (!name.trim() || !email.trim()) {
-        flash({ type: "error", text: "Bitte Name und E-Mail angeben." });
+        flash({ type: "error", text: t("booking.requiredNameEmail") });
         return;
       }
       if (!street.trim() || !zip.trim() || !city.trim()) {
-        flash({ type: "error", text: "Bitte Straße, PLZ und Ort angeben." });
+        flash({ type: "error", text: t("booking.requiredAddress") });
         return;
       }
 
@@ -294,7 +315,7 @@ export default function Booking() {
       const messageClean = message.trim();
 
       if (!emailClean) {
-        flash({ type: "error", text: "Bitte eine gültige E-Mail angeben." });
+        flash({ type: "error", text: t("booking.requiredValidEmail") });
         return;
       }
 
@@ -309,6 +330,7 @@ export default function Booking() {
           name: nameClean,
           email: emailClean,
           phone: phoneClean,
+          language,
           address: { street, zip, city, country },
         },
         message: messageClean,
@@ -347,9 +369,11 @@ export default function Booking() {
               name: nameClean,
               email: emailClean,
               phone: phoneClean,
+              language,
               address: { street, zip, city, country },
             },
             message: messageClean,
+            language,
           }),
         });
 
@@ -374,13 +398,16 @@ export default function Booking() {
       }
 
       if (mailSent) {
-        flash({ type: "success", text: "Vielen Dank! Deine Anfrage wurde übermittelt und die Bestätigungsmail wurde versendet." });
+        flash({ type: "success", text: t("booking.submitSuccess") });
       } else {
-        flash({ type: "error", text: `Anfrage gespeichert, aber Mailversand fehlgeschlagen (${mailErrorText || "unbekannter Fehler"}).` });
+        flash({
+          type: "error",
+          text: t("booking.submitMailFailed", { reason: mailErrorText || "" }),
+        });
       }
     } catch (err) {
       console.error("[booking] submit FAILED", err);
-      flash({ type: "error", text: err instanceof Error ? err.message : "Anfrage konnte nicht gesendet werden." });
+      flash({ type: "error", text: err instanceof Error ? err.message : t("booking.submitError") });
     } finally {
       setSubmitting(false);
     }
@@ -396,7 +423,7 @@ export default function Booking() {
       const next = new Date(d); next.setDate(next.getDate() + 1);
       const nextIso = formatLocalISO(next);
       const season = seasons.find((s) => iso >= s.startDate && iso < s.endDate);
-      const label = season?.name || "Standard";
+      const label = season?.name || t("booking.rateLabelStandard");
       const rate = season?.nightlyRate ?? defaultRate;
       // Kurtaxe für genau diese eine Nacht berechnen (nur Erwachsene)
       const taxObj = touristTaxForStay(taxBands, iso, nextIso, adults);
@@ -405,24 +432,24 @@ export default function Booking() {
       out.push({ date: iso, label, rate, tax, subtotal });
     }
     return out;
-  }, [propertyId, start, end, seasons, defaultRate, taxBands, adults]);
+  }, [propertyId, start, end, seasons, defaultRate, taxBands, adults, t]);
 
   return (
     <section className="space-y-6">
       <header className="text-center">
-        <h1 className="text-3xl font-semibold tracking-tight">Buchen – {propertyName}</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">{t("booking.heading", { propertyName })}</h1>
         <p className="mt-2 text-slate-600">
-          Wähle Zeitraum &amp; Gäste. Der Preis wird live berechnet (inkl. Endreinigung &amp; Kurtaxe ab 16 Jahren).
+          {t("booking.subheading")}
         </p>
       </header>
 
       {/* Formular */}
       <form id="booking-form" className="grid gap-4" onSubmit={submitRequest}>
         <div>
-          <Field label="Zeitraum wählen">
+          <Field label={t("booking.fieldDateRange")}>
             <DayPicker
               mode="range"
-              locale={de}
+              locale={dateFnsLocale}
               numberOfMonths={2}
               fromDate={new Date()}
               selected={range}
@@ -431,36 +458,36 @@ export default function Booking() {
             />
           </Field>
         </div>
-        <Field label="Erwachsene (≥16)">
+        <Field label={t("booking.fieldAdults")}>
           <input className="input" type="number" min={0} value={adults} onChange={(e)=>setAdults(Number(e.target.value))} />
         </Field>
-        <Field label="Kinder (0–15)">
+        <Field label={t("booking.fieldChildren")}>
           <input className="input" type="number" min={0} value={children} onChange={(e)=>setChildren(Number(e.target.value))} />
         </Field>
 
         {/* Kontakt */}
         <div className="grid gap-4">
-          <Field label="Name">
-            <input className="input" value={name} onChange={(e)=>setName(e.target.value)} placeholder="Vor- und Nachname" />
+          <Field label={t("booking.fieldName")}>
+            <input className="input" value={name} onChange={(e)=>setName(e.target.value)} placeholder={t("booking.placeholderName")} />
           </Field>
-          <Field label="E-Mail">
+          <Field label={t("booking.fieldEmail")}>
             <input className="input" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="name@example.com" />
           </Field>
-          <Field label="Telefon (optional)">
+          <Field label={t("booking.fieldPhoneOptional")}>
             <input className="input" value={phone} onChange={(e)=>setPhone(e.target.value)} placeholder="+49 …" />
           </Field>
 
           {/* NEU: Anschrift */}
           <div className="grid gap-4">
-            <Field label="Straße & Nr.">
+            <Field label={t("booking.fieldStreet")}>
               <input
                 className="input"
                 value={street}
                 onChange={(e)=>setStreet(e.target.value)}
-                placeholder="z. B. Spangerstraße 9"
+                placeholder={t("booking.placeholderStreet")}
               />
             </Field>
-            <Field label="PLZ">
+            <Field label={t("booking.fieldZip")}>
               <input
                 className="input"
                 value={zip}
@@ -468,85 +495,84 @@ export default function Booking() {
                 placeholder="27476"
               />
             </Field>
-            <Field label="Ort">
+            <Field label={t("booking.fieldCity")}>
               <input
                 className="input"
                 value={city}
                 onChange={(e)=>setCity(e.target.value)}
-                placeholder="Cuxhaven"
+                placeholder={t("booking.placeholderCity")}
               />
             </Field>
-            <Field label="Land">
+            <Field label={t("booking.fieldCountry")}>
               <input
                 className="input"
                 value={country}
                 onChange={(e)=>setCountry(e.target.value)}
-                placeholder="Deutschland"
+                placeholder={t("booking.placeholderCountry")}
               />
             </Field>
           </div>
 
           <div>
-            <Field label="Nachricht (optional)">
-              <textarea className="input" rows={3} value={message} onChange={(e)=>setMessage(e.target.value)} placeholder="z.B. Ankunftszeit, Fragen …" />
+            <Field label={t("booking.fieldMessageOptional")}>
+              <textarea className="input" rows={3} value={message} onChange={(e)=>setMessage(e.target.value)} placeholder={t("booking.placeholderMessage")} />
             </Field>
           </div>
         </div>
       {/* Ergebnis */}
       <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
         {loading ? (
-          <p className="text-slate-600">Laden …</p>
+          <p className="text-slate-600">{t("booking.loading")}</p>
         ) : error ? (
           <p className="text-red-700">{error}</p>
         ) : nights <= 0 ? (
-          <p className="text-slate-600">Bitte ein gültiges Datum wählen (mindestens eine Nacht).</p>
+          <p className="text-slate-600">{t("booking.invalidNightCount")}</p>
         ) : calc ? (
           <div className="grid gap-4">
             <div className="space-y-1">
-              <h2 className="text-lg font-semibold">Zusammenfassung</h2>
+              <h2 className="text-lg font-semibold">{t("booking.summaryTitle")}</h2>
               <dl className="space-y-1">
-                <SummaryItem label="Nächte" value={String(nights)} />
-                <SummaryItem label="Übernachtungen" value={fmt.format(calc.base.nightsTotal)} />
-                <SummaryItem label="Endreinigung" value={fmt.format(calc.base.cleaningFee)} />
-                <SummaryItem label="Kurtaxe (Erwachsene)" value={fmt.format(calc.tax.total)} />
+                <SummaryItem label={t("booking.summaryNights")} value={String(nights)} />
+                <SummaryItem label={t("booking.summaryStays")} value={fmt.format(calc.base.nightsTotal)} />
+                <SummaryItem label={t("booking.summaryCleaning")} value={fmt.format(calc.base.cleaningFee)} />
+                <SummaryItem label={t("booking.summaryTax")} value={fmt.format(calc.tax.total)} />
               </dl>
               <div className="mt-2 h-px bg-slate-200" />
               <dl>
-                <SummaryItem label="Gesamt" value={fmt.format(calc.grandTotal)} bold />
+                <SummaryItem label={t("booking.summaryTotal")} value={fmt.format(calc.grandTotal)} bold />
               </dl>
-              <p className="mt-2 text-xs text-slate-500">Kurtaxe ab 16 Jahren. Saisonpreise inkl. USt., Kurtaxe nach Ortsrecht.</p>
+              <p className="mt-2 text-xs text-slate-500">{t("booking.summaryHint")}</p>
             </div>
 
             <div className="space-y-2">
-              <h3 className="font-medium">Hinweise</h3>
+              <h3 className="font-medium">{t("booking.notesTitle")}</h3>
               <ul className="list-disc pl-5 text-sm text-slate-700">
-                <li><strong>Ende exkl.:</strong> Die Abreise-Nacht ist nicht berechnet.</li>
-                <li>In definierten Saisons gilt der jeweilige Nachtpreis. Außerhalb gilt der Standardpreis.</li>
-                <li>Kurtaxe je Nacht pro zahlender Person (≥16) gemäß Kurtaxe-Band.</li>
+                <li>{t("booking.noteEndExclusive")}</li>
+                <li>{t("booking.noteSeasonRates")}</li>
+                <li>{t("booking.noteTax")}</li>
               </ul>
             </div>
             <div>
               <details className="rounded-lg border border-slate-200 bg-slate-50 p-3 open:bg-white">
-                <summary className="cursor-pointer select-none font-medium">Preis je Nacht anzeigen</summary>
+                <summary className="cursor-pointer select-none font-medium">{t("booking.nightlyDetails")}</summary>
                 <div className="mt-2 overflow-x-auto">
                   <table className="min-w-full text-sm">
                     <caption className="sr-only">
-                      Preisaufschlüsselung pro Nacht für den ausgewählten Zeitraum
-                      inklusive Tarif, Kurtaxe und Gesamtsumme
+                      {t("booking.nightlyCaption")}
                     </caption>
                     <thead>
                       <tr className="text-left text-slate-600">
-                        <th scope="col" className="py-1 pr-3">Datum</th>
-                        <th scope="col" className="py-1 pr-3">Tarif</th>
-                        <th scope="col" className="py-1 pr-3 text-right">Preis / Nacht</th>
-                        <th scope="col" className="py-1 pr-3 text-right">Kurtaxe / Nacht</th>
-                        <th scope="col" className="py-1 pr-3 text-right">Summe / Nacht</th>
+                        <th scope="col" className="py-1 pr-3">{t("booking.colDate")}</th>
+                        <th scope="col" className="py-1 pr-3">{t("booking.colRateType")}</th>
+                        <th scope="col" className="py-1 pr-3 text-right">{t("booking.colRatePerNight")}</th>
+                        <th scope="col" className="py-1 pr-3 text-right">{t("booking.colTaxPerNight")}</th>
+                        <th scope="col" className="py-1 pr-3 text-right">{t("booking.colTotalPerNight")}</th>
                       </tr>
                     </thead>
                     <tbody>
                       {nightlyBreakdown.map((n) => (
                         <tr key={n.date} className="border-t border-slate-200">
-                          <td className="py-1 pr-3">{new Date(n.date+"T00:00:00").toLocaleDateString("de-DE")}</td>
+                          <td className="py-1 pr-3">{new Date(n.date+"T00:00:00").toLocaleDateString(locale)}</td>
                           <td className="py-1 pr-3">{n.label}</td>
                           <td className="py-1 pr-3 text-right">{fmt.format(n.rate)}</td>
                           <td className="py-1 pr-3 text-right">{fmt.format(n.tax)}</td>
@@ -554,19 +580,19 @@ export default function Booking() {
                         </tr>
                       ))}
                       <tr className="border-t-2 border-slate-300 font-semibold">
-                        <td className="py-1 pr-3" colSpan={4}>Summe Übernachtungen</td>
+                        <td className="py-1 pr-3" colSpan={4}>{t("booking.rowStayTotal")}</td>
                         <td className="py-1 pr-3 text-right">{fmt.format(calc.base.nightsTotal)}</td>
                       </tr>
                       <tr>
-                        <td className="py-1 pr-3" colSpan={4}>Endreinigung</td>
+                        <td className="py-1 pr-3" colSpan={4}>{t("booking.rowCleaning")}</td>
                         <td className="py-1 pr-3 text-right">{fmt.format(calc.base.cleaningFee)}</td>
                       </tr>
                       <tr>
-                        <td className="py-1 pr-3" colSpan={4}>Kurtaxe (gesamt)</td>
+                        <td className="py-1 pr-3" colSpan={4}>{t("booking.rowTaxTotal")}</td>
                         <td className="py-1 pr-3 text-right">{fmt.format(calc.tax.total)}</td>
                       </tr>
                       <tr className="border-t-2 border-slate-300 font-semibold">
-                        <td className="py-1 pr-3" colSpan={4}>Gesamt</td>
+                        <td className="py-1 pr-3" colSpan={4}>{t("booking.rowGrandTotal")}</td>
                         <td className="py-1 pr-3 text-right">{fmt.format(calc.grandTotal)}</td>
                       </tr>
                     </tbody>
@@ -576,20 +602,20 @@ export default function Booking() {
             </div>
           </div>
         ) : (
-          <p className="text-slate-600">Preis konnte nicht berechnet werden.</p>
+          <p className="text-slate-600">{t("booking.priceCalcError")}</p>
         )}
       </div>
       {avail === "checking" && (
-        <p className="text-sm text-slate-500">Verfügbarkeit wird geprüft …</p>
+        <p className="text-sm text-slate-500">{t("booking.availabilityChecking")}</p>
       )}
       {avail === "available" && (
-        <p className="text-sm text-green-700">Zeitraum ist aktuell verfügbar.</p>
+        <p className="text-sm text-green-700">{t("booking.availabilityAvailable")}</p>
       )}
       {avail === "unavailable" && (
-        <p className="text-sm text-red-700">Zeitraum ist leider bereits belegt.</p>
+        <p className="text-sm text-red-700">{t("booking.availabilityUnavailable")}</p>
       )}
       {nights > 0 && nights < MIN_NIGHTS && (
-        <p className="text-sm text-amber-700">Mindestaufenthalt: {MIN_NIGHTS} Nächte.</p>
+        <p className="text-sm text-amber-700">{t("booking.minStay", { nights: MIN_NIGHTS })}</p>
       )}
 
       <div className="space-y-2">
@@ -598,7 +624,7 @@ export default function Booking() {
           className="rounded-xl bg-[color:var(--ocean,#0e7490)] px-5 py-2 font-semibold text-white hover:opacity-90 disabled:opacity-60"
           disabled={!calc || nights <= 0 || nights < MIN_NIGHTS || submitting}
         >
-          {submitting ? "Sende …" : "Anfrage senden"}
+          {submitting ? t("booking.submitSending") : t("booking.submit")}
         </button>
       </div>
       </form>
@@ -616,8 +642,8 @@ export default function Booking() {
             type="button"
             onClick={() => setNotice(null)}
             className="rounded bg-white/20 px-2 py-1 text-sm hover:bg-white/30"
-            aria-label="Hinweis schließen"
-            title="Hinweis schließen"
+            aria-label={t("booking.closeNotice")}
+            title={t("booking.closeNotice")}
           >
             ✕
           </button>

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -4,8 +4,10 @@ import {
   buildGalleryVariantPath,
   GALLERY_IMAGES,
 } from "../lib/galleryImages";
+import { useT } from "../i18n/useLanguage";
 
 export default function Gallery() {
+  const t = useT();
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const lightboxTitleId = useId();
@@ -52,11 +54,10 @@ export default function Gallery() {
     <section className="mx-auto max-w-6xl">
       <div className="mb-5">
         <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">
-          Galerie
+          {t("gallery.title")}
         </h1>
         <p className="mt-1 text-slate-600">
-          Klick auf ein Bild für die große Ansicht. Mit den Pfeiltasten kannst
-          du durchblättern.
+          {t("gallery.intro")}
         </p>
       </div>
 
@@ -72,7 +73,7 @@ export default function Gallery() {
               src={buildGalleryVariantPath(fileName, 640)}
               srcSet={buildGallerySrcSet(fileName)}
               sizes="(max-width: 768px) 48vw, (max-width: 1024px) 31vw, 24vw"
-              alt={`Ferienwohnung Ansicht ${index + 1}`}
+              alt={t("gallery.imageAlt", { index: index + 1 })}
               className="aspect-[4/3] w-full object-cover"
               loading="lazy"
               decoding="async"
@@ -89,14 +90,14 @@ export default function Gallery() {
           aria-modal="true"
           aria-labelledby={lightboxTitleId}
         >
-          <h2 id={lightboxTitleId} className="sr-only">Große Bildansicht</h2>
+          <h2 id={lightboxTitleId} className="sr-only">{t("gallery.lightboxTitle")}</h2>
           <button
             ref={closeButtonRef}
             type="button"
             onClick={closeLightbox}
             className="absolute right-3 top-3 rounded-md bg-white/90 px-3 py-2 text-sm font-medium text-slate-900 hover:bg-white md:right-6 md:top-6"
           >
-            Schließen
+            {t("gallery.close")}
           </button>
 
           <button
@@ -106,7 +107,7 @@ export default function Gallery() {
               showPrevious();
             }}
             className="absolute left-2 top-1/2 -translate-y-1/2 rounded-md bg-white/90 px-3 py-2 text-2xl leading-none text-slate-900 hover:bg-white md:left-6"
-            aria-label="Vorheriges Bild"
+            aria-label={t("gallery.prev")}
           >
             ‹
           </button>
@@ -119,13 +120,13 @@ export default function Gallery() {
               src={buildGalleryVariantPath(GALLERY_IMAGES[activeIndex], 1600)}
               srcSet={buildGallerySrcSet(GALLERY_IMAGES[activeIndex])}
               sizes="(max-width: 768px) 92vw, (max-width: 1280px) 86vw, 1600px"
-              alt={`Ferienwohnung Ansicht ${activeIndex + 1}`}
+              alt={t("gallery.imageAlt", { index: activeIndex + 1 })}
               className="max-h-[85vh] max-w-full rounded-lg object-contain"
               loading="eager"
               decoding="async"
             />
             <figcaption className="mt-3 text-center text-sm text-white/90">
-              Bild {activeIndex + 1} von {GALLERY_IMAGES.length}
+              {t("gallery.count", { current: activeIndex + 1, total: GALLERY_IMAGES.length })}
             </figcaption>
           </figure>
 
@@ -136,7 +137,7 @@ export default function Gallery() {
               showNext();
             }}
             className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md bg-white/90 px-3 py-2 text-2xl leading-none text-slate-900 hover:bg-white md:right-6"
-            aria-label="Nächstes Bild"
+            aria-label={t("gallery.next")}
           >
             ›
           </button>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,11 +4,13 @@ import {
   buildGalleryVariantPath,
   GALLERY_IMAGES,
 } from "../lib/galleryImages";
+import { useT } from "../i18n/useLanguage";
 
 const SLIDESHOW_INTERVAL_MS = 9000;
 const SLIDESHOW_TRANSITION_MS = 3200;
 
 export default function Home() {
+  const t = useT();
   const totalSlides = GALLERY_IMAGES.length;
   const [activeSlide, setActiveSlide] = useState(0);
   const [isSliding, setIsSliding] = useState(false);
@@ -61,7 +63,7 @@ export default function Home() {
             src="/hero/cuxhaven-hero-1280.jpg"
             srcSet="/hero/cuxhaven-hero-640.jpg 640w, /hero/cuxhaven-hero-960.jpg 960w, /hero/cuxhaven-hero-1280.jpg 1280w"
             sizes="100vw"
-            alt="Meerblick"
+            alt={t("home.heroAlt")}
             className="h-full w-full object-cover"
             width={1280}
             height={960}
@@ -76,30 +78,29 @@ export default function Home() {
       <div className="relative z-10 mx-auto -mt-16 max-w-6xl px-4">
         <div className="air-card air-shadow-tier rounded-[14px] bg-white p-4 md:p-6">
           <h1 className="text-[28px] font-bold leading-[1.43] text-[color:var(--color-ink)]">
-            Ferienwohnung Antjes Ankerplatz
+            {t("home.title")}
           </h1>
           <p className="mt-1 text-[color:var(--color-body)]">
-            Maritimer Komfort, 2000 m bis zur Nordsee – jetzt Verfügbarkeit
-            prüfen.
+            {t("home.subtitle")}
           </p>
 
           <form className="mt-4 grid gap-3 md:grid-cols-4">
             <label className="md:col-span-1">
-              <span className="mb-1 block text-sm text-[color:var(--color-muted)]">Anreise</span>
+              <span className="mb-1 block text-sm text-[color:var(--color-muted)]">{t("home.arrival")}</span>
               <input
                 className="input"
                 type="date"
               />
             </label>
             <label className="md:col-span-1">
-              <span className="mb-1 block text-sm text-[color:var(--color-muted)]">Abreise</span>
+              <span className="mb-1 block text-sm text-[color:var(--color-muted)]">{t("home.departure")}</span>
               <input
                 className="input"
                 type="date"
               />
             </label>
             <label className="md:col-span-1">
-              <span className="mb-1 block text-sm text-[color:var(--color-muted)]">Gäste</span>
+              <span className="mb-1 block text-sm text-[color:var(--color-muted)]">{t("home.guests")}</span>
               <input
                 className="input"
                 type="number"
@@ -112,20 +113,20 @@ export default function Home() {
               type="button"
               onClick={() => location.assign("/book")}
             >
-              Verfügbarkeit prüfen
+              {t("home.checkAvailability")}
             </button>
           </form>
         </div>
       </div>
 
       <section className="mt-8 bg-[color:var(--color-surface-soft)] py-8 md:mt-12 md:py-12">
-        <h2 className="sr-only">Ausstattungsmerkmale</h2>
+        <h2 className="sr-only">{t("home.featuresTitle")}</h2>
         <div className="mx-auto grid max-w-6xl gap-4 px-4 md:grid-cols-4">
           {[
-            { t: "Strandnah", d: "20 Minuten zu Fuß" },
-            { t: "Kostenloses Parken", d: "Privatstellplatz" },
-            { t: "Haustiere erlaubt", d: "auf Anfrage" },
-            { t: "WLAN & Smart-TV", d: "inklusive" },
+            { t: t("home.featureBeach"), d: t("home.featureBeachDesc") },
+            { t: t("home.featureParking"), d: t("home.featureParkingDesc") },
+            { t: t("home.featurePets"), d: t("home.featurePetsDesc") },
+            { t: t("home.featureWifi"), d: t("home.featureWifiDesc") },
           ].map((it) => (
             <article key={it.t} className="air-card rounded-[14px] bg-white p-4">
               <h3 className="text-base font-semibold text-[color:var(--color-ink)]">{it.t}</h3>
@@ -138,27 +139,22 @@ export default function Home() {
       <section className="mx-auto max-w-6xl px-4 py-10 md:py-12">
         <div className="air-card mb-6 rounded-[14px] bg-white p-5 md:p-6">
           <h2 className="text-[21px] font-bold leading-[1.43] text-[color:var(--color-ink)] md:text-[22px] md:font-medium md:leading-[1.18]">
-            Wohnungsbeschreibung
+            {t("home.descriptionTitle")}
           </h2>
           <p className="mt-2 text-[color:var(--color-body)]">
-            Antjes Ankerplatz ist eine gemütliche, maritime Ferienwohnung für
-            entspannte Tage an der Nordsee. Die Wohnung bietet einen hellen
-            Wohnbereich, eine gut ausgestattete Küche und komfortable
-            Schlafmöglichkeiten für Paare und Familien.
+            {t("home.descriptionP1")}
           </p>
           <p className="mt-2 text-[color:var(--color-body)]">
-            Dank der strandnahen Lage, eigenem Stellplatz und kurzer Wege zu
-            Einkaufsmöglichkeiten ist sie ein idealer Ausgangspunkt für
-            Erholung, Spaziergänge und Ausflüge rund um Cuxhaven.
+            {t("home.descriptionP2")}
           </p>
         </div>
 
         <div className="mb-5">
           <h2 className="text-[21px] font-bold leading-[1.43] text-[color:var(--color-ink)] md:text-[22px] md:font-medium md:leading-[1.18]">
-            Bildergalerie
+            {t("home.galleryTitle")}
           </h2>
           <p className="mt-1 text-[color:var(--color-muted)]">
-            Die Bilder laufen automatisch von rechts nach links durch.
+            {t("home.galleryHint")}
           </p>
         </div>
 
@@ -174,7 +170,7 @@ export default function Home() {
                 src={buildGalleryVariantPath(GALLERY_IMAGES[activeSlide], 1600)}
                 srcSet={buildGallerySrcSet(GALLERY_IMAGES[activeSlide])}
                 sizes="(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1200px"
-                alt={`Ferienwohnung Ansicht ${activeSlide + 1}`}
+                alt={t("home.galleryAlt", { index: activeSlide + 1 })}
                 className="h-full w-full object-cover"
                 loading="eager"
                 decoding="async"
@@ -190,7 +186,7 @@ export default function Home() {
                 src={buildGalleryVariantPath(GALLERY_IMAGES[nextSlide], 1600)}
                 srcSet={buildGallerySrcSet(GALLERY_IMAGES[nextSlide])}
                 sizes="(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1200px"
-                alt={`Ferienwohnung Ansicht ${nextSlide + 1}`}
+                alt={t("home.galleryAlt", { index: nextSlide + 1 })}
                 className="h-full w-full object-cover"
                 loading="lazy"
                 decoding="async"
@@ -198,7 +194,7 @@ export default function Home() {
             </picture>
             <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-black/10 to-transparent" />
             <div className="absolute bottom-3 right-3 rounded-full bg-black/60 px-3 py-1 text-xs font-medium text-white">
-              Bild {activeSlide + 1} von {totalSlides}
+              {t("home.galleryCount", { current: activeSlide + 1, total: totalSlides })}
             </div>
           </div>
         </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../app/providers/AuthProvider';
 import { auth } from '../lib/firebaseAuth';
+import { useT } from '../i18n/useLanguage';
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
@@ -15,6 +16,7 @@ import {
  * - Weiterleitung auf die Seite, die den Nutzer hierher geschickt hat (state.from)
  */
 export default function Login() {
+  const t = useT();
   const { user } = useAuth();
   const nav = useNavigate();
   const loc = useLocation();
@@ -35,7 +37,7 @@ export default function Login() {
       await signInWithEmailAndPassword(auth, email.trim(), pw);
       nav(from, { replace: true });
     } catch (err: unknown) {
-      setMsg(err instanceof Error ? err.message : 'Login fehlgeschlagen.');
+      setMsg(err instanceof Error ? err.message : t("login.errorLogin"));
     } finally {
       setLoading(false);
     }
@@ -47,22 +49,22 @@ export default function Login() {
     setLoading(true);
     try {
       await createUserWithEmailAndPassword(auth, email.trim(), pw);
-      setMsg('Konto angelegt. Du bist jetzt angemeldet.');
+      setMsg(t("login.successRegister"));
       nav(from, { replace: true });
     } catch (err: unknown) {
-      setMsg(err instanceof Error ? err.message : 'Registrierung fehlgeschlagen.');
+      setMsg(err instanceof Error ? err.message : t("login.errorRegister"));
     } finally {
       setLoading(false);
     }
   }
 
   async function doReset() {
-    if (!email) { setMsg('Bitte E-Mail eingeben, um einen Reset-Link zu erhalten.'); return; }
+    if (!email) { setMsg(t("login.resetNeedEmail")); return; }
     try {
       await sendPasswordResetEmail(auth, email.trim());
-      setMsg('Passwort-Reset gesendet. Bitte Posteingang prüfen.');
+      setMsg(t("login.resetSent"));
     } catch (err: unknown) {
-      setMsg(err instanceof Error ? err.message : 'Reset fehlgeschlagen.');
+      setMsg(err instanceof Error ? err.message : t("login.resetError"));
     }
   }
 
@@ -73,20 +75,20 @@ export default function Login() {
   if (user) {
     return (
       <section className="space-y-4">
-        <h1 className="text-xl font-semibold">Admin</h1>
-        <p>Angemeldet als <strong>{user.email}</strong></p>
-        <button onClick={doLogout} className="rounded bg-gray-800 px-3 py-2 text-white">Logout</button>
+        <h1 className="text-xl font-semibold">{t("login.adminTitle")}</h1>
+        <p>{t("login.loggedInAs", { email: user.email ?? "" })}</p>
+        <button onClick={doLogout} className="rounded bg-gray-800 px-3 py-2 text-white">{t("login.logout")}</button>
       </section>
     );
   }
 
   return (
     <section className="mx-auto max-w-md space-y-6">
-      <h1 className="text-xl font-semibold">{mode === 'login' ? 'Anmelden' : 'Registrieren'}</h1>
+      <h1 className="text-xl font-semibold">{mode === 'login' ? t("login.titleLogin") : t("login.titleRegister")}</h1>
 
       <form onSubmit={mode === 'login' ? doLogin : doRegister} className="space-y-3">
         <label className="block text-sm">
-          <span className="mb-1 block text-slate-600">E-Mail</span>
+          <span className="mb-1 block text-slate-600">{t("login.email")}</span>
           <input
             className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
             type="email"
@@ -98,7 +100,7 @@ export default function Login() {
           />
         </label>
         <label className="block text-sm">
-          <span className="mb-1 block text-slate-600">Passwort</span>
+          <span className="mb-1 block text-slate-600">{t("login.password")}</span>
           <input
             className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
             type="password"
@@ -113,11 +115,11 @@ export default function Login() {
 
         <div className="flex items-center justify-between">
           <button disabled={loading} className="rounded-xl bg-[color:var(--ocean,#0e7490)] px-4 py-2 font-semibold text-white hover:opacity-90">
-            {mode === 'login' ? 'Anmelden' : 'Registrieren'}
+            {mode === 'login' ? t("login.titleLogin") : t("login.titleRegister")}
           </button>
           {mode === 'login' && (
             <button type="button" className="text-sm underline" onClick={doReset}>
-              Passwort vergessen?
+              {t("login.forgot")}
             </button>
           )}
         </div>
@@ -128,16 +130,16 @@ export default function Login() {
       <div className="text-sm text-slate-600">
         {mode === 'login' ? (
           <>
-            Kein Konto?{' '}
+            {t("login.noAccount")}{" "}
             <button type="button" className="underline" onClick={() => setMode('register')}>
-              Jetzt registrieren
+              {t("login.registerNow")}
             </button>
           </>
         ) : (
           <>
-            Schon ein Konto?{' '}
+            {t("login.hasAccount")}{" "}
             <button type="button" className="underline" onClick={() => setMode('login')}>
-              Zum Login
+              {t("login.toLogin")}
             </button>
           </>
         )}

--- a/src/pages/Prices.tsx
+++ b/src/pages/Prices.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { getFirstPropertyLite, getPropertyLite, listSeasonsLite } from "../lib/publicPricingData";
+import { useLanguage, useT } from "../i18n/useLanguage";
 
 type Row = {
   id: string;
@@ -11,9 +12,11 @@ type Row = {
 };
 
 export default function Prices() {
+  const { locale } = useLanguage();
+  const t = useT();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [propertyName, setPropertyName] = useState<string>("Ferienwohnung");
+  const [propertyName, setPropertyName] = useState<string>(t("prices.defaultPropertyName"));
   const [currency, setCurrency] = useState<string>("EUR");
   const [defaultNightlyRate, setDefaultNightlyRate] = useState<number>(0);
   const [cleaningFee, setCleaningFee] = useState<number>(0);
@@ -59,7 +62,7 @@ export default function Prices() {
           }
         }
 
-        setPropertyName(resolvedProp.name || "Ferienwohnung");
+        setPropertyName(resolvedProp.name || t("prices.defaultPropertyName"));
         setCurrency(resolvedProp.currency || "EUR");
         setDefaultNightlyRate(resolvedProp.defaultNightlyRate || 0);
         setCleaningFee(resolvedProp.cleaningFee || 0);
@@ -76,43 +79,43 @@ export default function Prices() {
           }))
         );
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Preise konnten nicht geladen werden.");
+        setError(e instanceof Error ? e.message : t("prices.errorLoad"));
       } finally {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [t]);
 
   const formatter = useMemo(
-    () => new Intl.NumberFormat("de-DE", { style: "currency", currency }),
-    [currency]
+    () => new Intl.NumberFormat(locale, { style: "currency", currency }),
+    [currency, locale]
   );
   const fmtDate = (iso: string) =>
-    new Date(iso + "T00:00:00").toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" });
+    new Date(iso + "T00:00:00").toLocaleDateString(locale, { day: "2-digit", month: "2-digit", year: "numeric" });
 
   return (
     <section className="space-y-8">
       <header className="text-center">
-        <h1 className="text-3xl font-semibold tracking-tight">{propertyName} – Preise</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">{t("prices.title", { propertyName })}</h1>
         <p className="mt-2 text-slate-600">
-          Transparente Saisonpreise &amp; Standardpreis. Endreinigung und Kurtaxe separat wie angegeben.
+          {t("prices.subtitle")}
         </p>
       </header>
 
       {/* Standardpreis & Endreinigung */}
       <div className="grid gap-4 md:grid-cols-2">
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="text-lg font-semibold">Standardpreis außerhalb von Saisons</h2>
-          <p className="mt-1 text-2xl font-bold">{formatter.format(defaultNightlyRate)} <span className="text-base font-normal text-slate-600">/ Nacht</span></p>
+          <h2 className="text-lg font-semibold">{t("prices.standardTitle")}</h2>
+          <p className="mt-1 text-2xl font-bold">{formatter.format(defaultNightlyRate)} <span className="text-base font-normal text-slate-600">{t("prices.perNight")}</span></p>
           <p className="mt-2 text-sm text-slate-600">
-            Gilt für Nächte, die in keine definierte Saison fallen.
+            {t("prices.standardHint")}
           </p>
         </div>
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="text-lg font-semibold">Endreinigung</h2>
+          <h2 className="text-lg font-semibold">{t("prices.cleaningTitle")}</h2>
           <p className="mt-1 text-2xl font-bold">{formatter.format(cleaningFee)}</p>
           <p className="mt-2 text-sm text-slate-600">
-            Einmalig pro Aufenthalt. Kurtaxe nach lokaler Satzung ggf. zusätzlich.
+            {t("prices.cleaningHint")}
           </p>
         </div>
       </div>
@@ -120,30 +123,29 @@ export default function Prices() {
       {/* Saisonpreise */}
       <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="border-b px-4 py-3">
-          <h2 className="text-lg font-semibold">Saisonpreise</h2>
+          <h2 className="text-lg font-semibold">{t("prices.seasonsTitle")}</h2>
         </div>
 
         {loading ? (
-          <div className="px-4 py-6 text-slate-600">Laden …</div>
+          <div className="px-4 py-6 text-slate-600">{t("prices.loading")}</div>
         ) : error ? (
           <div className="px-4 py-6 text-red-700">
             {error}
           </div>
         ) : rows.length === 0 ? (
-          <div className="px-4 py-6 text-slate-600">Noch keine Saisons erfasst.</div>
+          <div className="px-4 py-6 text-slate-600">{t("prices.empty")}</div>
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
               <caption className="sr-only">
-                Saisonpreise für {propertyName} mit Zeitraum, Tarifname, Preis pro
-                Nacht und Mindestnächten
+                {t("prices.caption", { propertyName })}
               </caption>
               <thead className="bg-slate-50 text-slate-700">
                 <tr>
-                  <Th>Zeitraum</Th>
-                  <Th>Name</Th>
-                  <Th className="text-right">Preis/Nacht</Th>
-                  <Th className="text-right">Min. Nächte</Th>
+                  <Th>{t("prices.colRange")}</Th>
+                  <Th>{t("prices.colName")}</Th>
+                  <Th className="text-right">{t("prices.colRate")}</Th>
+                  <Th className="text-right">{t("prices.colMinNights")}</Th>
                 </tr>
               </thead>
               <tbody>
@@ -151,7 +153,7 @@ export default function Prices() {
                   <tr key={r.id} className="border-t">
                     <Td>
                       {fmtDate(r.startDate)} – {fmtDate(r.endDate)}
-                      <span className="ml-1 text-xs text-slate-500">(Ende exkl.)</span>
+                      <span className="ml-1 text-xs text-slate-500">{t("prices.rangeEndExclusive")}</span>
                     </Td>
                     <Td>{r.name}</Td>
                     <Td className="text-right">{formatter.format(r.nightlyRate)}</Td>
@@ -166,15 +168,15 @@ export default function Prices() {
 
       {/* CTA */}
       <div className="rounded-2xl bg-[color:var(--seafoam,#e0f2f1)] px-6 py-6 text-center md:py-8">
-        <h3 className="text-xl font-semibold">Fragen zum Zeitraum oder Preis?</h3>
+        <h3 className="text-xl font-semibold">{t("prices.ctaTitle")}</h3>
         <p className="mt-1 text-slate-700">
-          Prüfe die Verfügbarkeit und erhalte den Gesamtpreis direkt im nächsten Schritt.
+          {t("prices.ctaText")}
         </p>
         <a
           href="/book"
           className="mt-4 inline-flex items-center justify-center rounded-full bg-[color:var(--ocean,#0e7490)] px-5 py-2 text-white hover:opacity-90"
         >
-          Jetzt Verfügbarkeit prüfen
+          {t("prices.ctaButton")}
         </a>
       </div>
     </section>

--- a/tests/e2e/public/smoke.spec.ts
+++ b/tests/e2e/public/smoke.spec.ts
@@ -71,6 +71,19 @@ test.describe("Public routes smoke", () => {
     });
   });
 
+  test("language toggle switches to english labels", async ({ page }) => {
+    await runSmoke(page, "/", async (activePage) => {
+      await expect(activePage.getByRole("button", { name: "EN" })).toBeVisible();
+      await activePage.getByRole("button", { name: "EN" }).click();
+      await expect(activePage.getByRole("link", { name: "Gallery" })).toBeVisible();
+      await expect(activePage.getByRole("link", { name: "Prices" })).toBeVisible();
+      await expect(activePage.getByRole("link", { name: "Book" })).toBeVisible();
+      await expect(
+        activePage.getByRole("button", { name: "Check availability" }),
+      ).toBeVisible();
+    });
+  });
+
   test("gallery page renders heading", async ({ page }) => {
     await runSmoke(page, "/gallery", async (activePage) => {
       await expect(


### PR DESCRIPTION
## Summary
- add a frontend i18n foundation with de/en dictionaries, language context, and translation hook
- add a DE | EN switch in the header and place it on the same row as the brand (right-aligned)
- keep German as default language and persist selected language in local storage
- localize public page UI copy for Home, Gallery, Prices, Booking, Login, routes loading state, and footer links
- localize date/currency/day-picker formatting based on selected language
- include language in booking/admin action payload plumbing on the frontend and booking schema
- add a smoke e2e check for language toggle behavior

## Validation
- npm run lint:frontend
- npm run typecheck:frontend
- npm run build:frontend
- npm run e2e -- tests/e2e/public/smoke.spec.ts
- npm run e2e -- tests/e2e/booking/booking-flow.spec.ts

## Notes
- As requested, this PR intentionally excludes backend-php changes because that path is ignored in this repository.