### PR TITLE
Add category-based cookie consent and consent-gated analytics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { NavBar } from "./components/NavBar";
 import { AppRoutes } from "./app/routes";
 import { useLocation } from "react-router-dom";
 import { useT } from "./i18n/useLanguage";
+import { CookieBanner } from "./components/CookieBanner";
+import { ConsentAnalytics } from "./components/ConsentAnalytics";
 
 export default function App() {
   const t = useT();
@@ -40,6 +42,9 @@ export default function App() {
           <a href="/datenschutz" className="mx-2 underline">{t("app.footer.privacy")}</a>
         </div>
       </footer>
+
+      <CookieBanner />
+      <ConsentAnalytics />
     </div>
   );
 }

--- a/src/components/ConsentAnalytics.tsx
+++ b/src/components/ConsentAnalytics.tsx
@@ -1,0 +1,112 @@
+import { useEffect } from "react";
+import {
+  COOKIE_CONSENT_UPDATED_EVENT,
+  readCookieConsent,
+} from "../lib/cookieConsent";
+import type { CookieConsent } from "../lib/cookieConsent";
+
+type GtagConsentState = "granted" | "denied";
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID?.trim();
+let initializedForMeasurementId: string | null = null;
+
+function toState(allowed: boolean): GtagConsentState {
+  return allowed ? "granted" : "denied";
+}
+
+function ensureGtagBase() {
+  if (!window.dataLayer) {
+    window.dataLayer = [];
+  }
+
+  if (!window.gtag) {
+    window.gtag = (...args: unknown[]) => {
+      window.dataLayer.push(args);
+    };
+  }
+}
+
+function applyConsent(consent: CookieConsent | null) {
+  ensureGtagBase();
+
+  window.gtag("consent", "update", {
+    analytics_storage: toState(Boolean(consent?.statistics)),
+    ad_storage: toState(Boolean(consent?.marketing)),
+    ad_user_data: toState(Boolean(consent?.marketing)),
+    ad_personalization: toState(Boolean(consent?.marketing)),
+  });
+}
+
+function loadGtagScript(measurementId: string) {
+  const existing = document.querySelector<HTMLScriptElement>(
+    `script[src="https://www.googletagmanager.com/gtag/js?id=${measurementId}"]`
+  );
+
+  if (existing) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+  document.head.appendChild(script);
+}
+
+function initializeGtag(measurementId: string) {
+  if (initializedForMeasurementId === measurementId) {
+    return;
+  }
+
+  ensureGtagBase();
+  window.gtag("js", new Date());
+  window.gtag("config", measurementId, { anonymize_ip: true });
+  initializedForMeasurementId = measurementId;
+}
+
+export function ConsentAnalytics() {
+  useEffect(() => {
+    if (!GA_MEASUREMENT_ID) {
+      return;
+    }
+
+    ensureGtagBase();
+
+    window.gtag("consent", "default", {
+      analytics_storage: "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+    });
+
+    const syncConsent = (consent: CookieConsent | null) => {
+      applyConsent(consent);
+
+      if (consent?.statistics) {
+        loadGtagScript(GA_MEASUREMENT_ID);
+        initializeGtag(GA_MEASUREMENT_ID);
+      }
+    };
+
+    syncConsent(readCookieConsent());
+
+    const onConsentChanged = (event: Event) => {
+      const customEvent = event as CustomEvent<CookieConsent>;
+      syncConsent(customEvent.detail ?? readCookieConsent());
+    };
+
+    window.addEventListener(COOKIE_CONSENT_UPDATED_EVENT, onConsentChanged);
+
+    return () => {
+      window.removeEventListener(COOKIE_CONSENT_UPDATED_EVENT, onConsentChanged);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useT } from "../i18n/useLanguage";
+import {
+  buildCookieConsent,
+  readCookieConsent,
+  writeCookieConsent,
+} from "../lib/cookieConsent";
+
+export function CookieBanner() {
+  const t = useT();
+  const [visible, setVisible] = useState(false);
+  const [statisticsEnabled, setStatisticsEnabled] = useState(false);
+  const [marketingEnabled, setMarketingEnabled] = useState(false);
+
+  useEffect(() => {
+    const savedConsent = readCookieConsent();
+
+    if (!savedConsent) {
+      setVisible(true);
+      return;
+    }
+
+    setStatisticsEnabled(savedConsent.statistics);
+    setMarketingEnabled(savedConsent.marketing);
+    setVisible(false);
+  }, []);
+
+  const saveConsent = (options: { statistics: boolean; marketing: boolean }) => {
+    writeCookieConsent(buildCookieConsent(options));
+    setVisible(false);
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <aside
+      className="fixed inset-x-3 bottom-24 z-50 rounded-2xl border border-[color:var(--color-hairline)] bg-white p-4 shadow-xl md:inset-x-auto md:bottom-6 md:right-6 md:w-[min(560px,calc(100vw-3rem))]"
+      role="dialog"
+      aria-live="polite"
+      aria-label={t("cookie.title")}
+    >
+      <h2 className="text-base font-semibold text-[color:var(--color-ink)]">{t("cookie.title")}</h2>
+      <p className="mt-2 text-sm text-[color:var(--color-body)]">{t("cookie.description")}</p>
+
+      <div className="mt-4 space-y-3">
+        <div className="rounded-xl border border-[color:var(--color-hairline-soft)] bg-[color:var(--color-surface-soft)] p-3">
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-medium text-[color:var(--color-ink)]">{t("cookie.categoryNecessary.title")}</p>
+            <span className="rounded-full bg-white px-2 py-1 text-xs text-[color:var(--color-muted)]">
+              {t("cookie.alwaysActive")}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-[color:var(--color-muted)]">{t("cookie.categoryNecessary.description")}</p>
+        </div>
+
+        <label className="flex items-start gap-3 rounded-xl border border-[color:var(--color-hairline-soft)] p-3">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={statisticsEnabled}
+            onChange={(event) => setStatisticsEnabled(event.target.checked)}
+          />
+          <span>
+            <span className="block font-medium text-[color:var(--color-ink)]">{t("cookie.categoryStatistics.title")}</span>
+            <span className="mt-1 block text-sm text-[color:var(--color-muted)]">{t("cookie.categoryStatistics.description")}</span>
+          </span>
+        </label>
+
+        <label className="flex items-start gap-3 rounded-xl border border-[color:var(--color-hairline-soft)] p-3">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={marketingEnabled}
+            onChange={(event) => setMarketingEnabled(event.target.checked)}
+          />
+          <span>
+            <span className="block font-medium text-[color:var(--color-ink)]">{t("cookie.categoryMarketing.title")}</span>
+            <span className="mt-1 block text-sm text-[color:var(--color-muted)]">{t("cookie.categoryMarketing.description")}</span>
+          </span>
+        </label>
+      </div>
+
+      <p className="mt-3 text-sm text-[color:var(--color-muted)]">
+        <Link className="underline" to="/datenschutz">
+          {t("cookie.privacyLink")}
+        </Link>
+      </p>
+
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          className="air-btn-secondary"
+          onClick={() => saveConsent({ statistics: false, marketing: false })}
+        >
+          {t("cookie.essentialOnly")}
+        </button>
+        <button
+          type="button"
+          className="air-btn-secondary"
+          onClick={() =>
+            saveConsent({ statistics: statisticsEnabled, marketing: marketingEnabled })
+          }
+        >
+          {t("cookie.saveSelection")}
+        </button>
+        <button
+          type="button"
+          className="air-btn-primary"
+          onClick={() => saveConsent({ statistics: true, marketing: true })}
+        >
+          {t("cookie.acceptAll")}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -19,6 +19,24 @@ export const de: TranslationDictionary = {
   "app.footer.imprint": "Impressum",
   "app.footer.privacy": "Datenschutz",
 
+  "cookie.title": "Cookie-Einstellungen",
+  "cookie.description":
+    "Wir nutzen notwendige Cookies und bieten dir optionale Kategorien für Statistik und Marketing an.",
+  "cookie.alwaysActive": "Immer aktiv",
+  "cookie.categoryNecessary.title": "Notwendige Cookies",
+  "cookie.categoryNecessary.description":
+    "Erforderlich für Basisfunktionen wie Seitennavigation und Sicherheit.",
+  "cookie.categoryStatistics.title": "Statistik",
+  "cookie.categoryStatistics.description":
+    "Hilft uns zu verstehen, wie Besucher die Website nutzen, damit wir sie verbessern können.",
+  "cookie.categoryMarketing.title": "Marketing",
+  "cookie.categoryMarketing.description":
+    "Erlaubt personalisierte Inhalte und Werbe-Messung über Drittanbieter.",
+  "cookie.privacyLink": "Mehr in der Datenschutzerklärung",
+  "cookie.essentialOnly": "Nur notwendige",
+  "cookie.saveSelection": "Auswahl speichern",
+  "cookie.acceptAll": "Alle akzeptieren",
+
   "routes.loading": "Laden …",
 
   "home.heroAlt": "Meerblick",
@@ -197,6 +215,23 @@ export const en: TranslationDictionary = {
   "app.footer.bookNow": "Book now",
   "app.footer.imprint": "Legal notice",
   "app.footer.privacy": "Privacy",
+  "cookie.title": "Cookie settings",
+  "cookie.description":
+    "We use essential cookies and offer optional categories for statistics and marketing.",
+  "cookie.alwaysActive": "Always active",
+  "cookie.categoryNecessary.title": "Essential cookies",
+  "cookie.categoryNecessary.description":
+    "Required for basic features such as site navigation and security.",
+  "cookie.categoryStatistics.title": "Statistics",
+  "cookie.categoryStatistics.description":
+    "Helps us understand how visitors use the website so we can improve it.",
+  "cookie.categoryMarketing.title": "Marketing",
+  "cookie.categoryMarketing.description":
+    "Allows personalized content and ad measurement through third parties.",
+  "cookie.privacyLink": "Read more in the privacy policy",
+  "cookie.essentialOnly": "Essential only",
+  "cookie.saveSelection": "Save selection",
+  "cookie.acceptAll": "Accept all",
 
   "routes.loading": "Loading …",
 

--- a/src/lib/cookieConsent.ts
+++ b/src/lib/cookieConsent.ts
@@ -1,0 +1,88 @@
+export const COOKIE_CONSENT_KEY = "aa_cookie_consent_v1";
+export const COOKIE_CONSENT_UPDATED_EVENT = "aa:cookie-consent-updated";
+
+export type CookieConsentCategory = "necessary" | "statistics" | "marketing";
+
+export type CookieConsent = {
+  version: 1;
+  necessary: true;
+  statistics: boolean;
+  marketing: boolean;
+  updatedAt: string;
+};
+
+function isValidConsent(input: unknown): input is CookieConsent {
+  if (!input || typeof input !== "object") {
+    return false;
+  }
+
+  const candidate = input as Partial<CookieConsent>;
+
+  return (
+    candidate.version === 1 &&
+    candidate.necessary === true &&
+    typeof candidate.statistics === "boolean" &&
+    typeof candidate.marketing === "boolean" &&
+    typeof candidate.updatedAt === "string"
+  );
+}
+
+export function buildCookieConsent(options: {
+  statistics: boolean;
+  marketing: boolean;
+}): CookieConsent {
+  return {
+    version: 1,
+    necessary: true,
+    statistics: options.statistics,
+    marketing: options.marketing,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function readCookieConsent(): CookieConsent | null {
+  try {
+    const raw = localStorage.getItem(COOKIE_CONSENT_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    return isValidConsent(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCookieConsent(consent: CookieConsent) {
+  try {
+    localStorage.setItem(COOKIE_CONSENT_KEY, JSON.stringify(consent));
+  } catch {
+    return;
+  }
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(COOKIE_CONSENT_UPDATED_EVENT, { detail: consent })
+    );
+  }
+}
+
+export function hasCookieConsent(
+  category: CookieConsentCategory,
+  consent: CookieConsent | null
+): boolean {
+  if (category === "necessary") {
+    return true;
+  }
+
+  if (!consent) {
+    return false;
+  }
+
+  if (category === "statistics") {
+    return consent.statistics;
+  }
+
+  return consent.marketing;
+}

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -11,7 +11,9 @@ export default function Privacy() {
           <div className="mb-6">
             <h2 className="text-xl font-bold mb-2">Cookies</h2>
             <p>
-              Unsere Website verwendet Cookies, um grundlegende Funktionen sicherzustellen.
+              Unsere Website verwendet notwendige Cookies, um grundlegende Funktionen sicherzustellen.
+              Optional können Statistik- und Marketing-Cookies aktiviert werden. Diese Einwilligung
+              kann jederzeit durch das Löschen der Browserdaten neu gesetzt werden.
             </p>
           </div>
         </li>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GA_MEASUREMENT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tests/e2e/public/smoke.spec.ts
+++ b/tests/e2e/public/smoke.spec.ts
@@ -73,8 +73,13 @@ test.describe("Public routes smoke", () => {
 
   test("language toggle switches to english labels", async ({ page }) => {
     await runSmoke(page, "/", async (activePage) => {
-      await expect(activePage.getByRole("button", { name: "EN" })).toBeVisible();
-      await activePage.getByRole("button", { name: "EN" }).click();
+      const languageSwitch = activePage.getByRole("group", { name: /sprache|language/i });
+      const englishButton = languageSwitch.getByRole("button", {
+        name: "EN",
+        exact: true,
+      });
+      await expect(englishButton).toBeVisible();
+      await englishButton.click();
       await expect(activePage.getByRole("link", { name: "Gallery" })).toBeVisible();
       await expect(activePage.getByRole("link", { name: "Prices" })).toBeVisible();
       await expect(activePage.getByRole("link", { name: "Book" })).toBeVisible();


### PR DESCRIPTION
## Summary
- add a category-based cookie banner with necessary, statistics, and marketing choices
- persist consent decisions in localStorage with a shared consent utility and update event
- load Google Analytics only after statistics consent and update Google Consent Mode states
- wire new cookie i18n labels (DE/EN) and add GA env typing

## Testing
- npm run lint:frontend
- npm run build:frontend