### PR TITLE
[codex] SEO optimizations for the holiday apartment site

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,14 @@ VITE_ASSET_BASE_URL=
 VITE_FIRESTORE_DEBUG=0
 VITE_USE_EMULATORS=0
 VITE_AUTH_EMULATOR=0
+VITE_GA_MEASUREMENT_ID=
+VITE_SITE_URL=https://www.deine-domain.de
 ```
 
 Notes:
 - `VITE_DEFAULT_PROPERTY_ID` is required for booking/admin data loading.
 - If `VITE_MAIL_API_URL` is not set, frontend falls back to `/api/send-booking-mail.php`.
+- `VITE_SITE_URL` is used to generate canonical URLs, `robots.txt`, and `sitemap.xml` during the build.
 
 ### 3. Run frontend
 
@@ -97,11 +100,41 @@ npm --prefix functions run serve
 - `npm run lint:frontend` lint frontend
 - `npm run typecheck:frontend` TypeScript project references check (`tsc -b`)
 - `npm run build:frontend` build frontend
+- `npm run build:frontend` build frontend and generate SEO assets (`robots.txt`, `sitemap.xml`)
 - `npm run lint:functions` lint functions
 - `npm run build:functions` build functions
+- `npm run seed:property` idempotent Firestore seed/repair for `properties/{id}` (+ optional `members/{uid}`)
 - `npm run lint` alias for `lint:frontend`
 - `npm run build` alias for `build:frontend`
 - `npm run ci` run frontend + functions checks end-to-end
+
+### Seed Property and Member (Recovery Helper)
+
+Use this when `properties` was deleted or needs to be recreated quickly.
+
+Example:
+
+```bash
+npm run seed:property -- \
+  --propertyId HiiCb9HW986xnpEnFh80 \
+  --adminEmail your-admin@example.com
+```
+
+What it does:
+- upserts `properties/{propertyId}` with safe defaults
+- optionally resolves auth user by `--adminEmail` and upserts `properties/{propertyId}/members/{uid}` with role `manager`
+
+Credential sources (first match wins):
+- `--serviceAccount <path>` or `FIREBASE_SERVICE_ACCOUNT_PATH`
+- `FIREBASE_SERVICE_ACCOUNT_JSON`
+- `GOOGLE_APPLICATION_CREDENTIALS`
+- fallback file: `sa-keys/antjes-ankerplatz-admin.json`
+
+Dry run:
+
+```bash
+npm run seed:property -- --propertyId HiiCb9HW986xnpEnFh80 --adminEmail your-admin@example.com --dryRun
+```
 
 ### Functions (`functions/package.json`)
 
@@ -157,6 +190,8 @@ Optional:
 - `VITE_FIRESTORE_DEBUG`
 - `VITE_USE_EMULATORS`
 - `VITE_AUTH_EMULATOR`
+- `VITE_GA_MEASUREMENT_ID` (loads Google Analytics only after statistics consent)
+- `VITE_SITE_URL` (base URL for canonical tags and sitemap generation)
 
 Important:
 - Do **not** use `VITE_MAIL_API_KEY`. The frontend no longer sends a mail API key.

--- a/index.html
+++ b/index.html
@@ -1,12 +1,27 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Antjes Ankerplatz</title>
+    <meta
+      name="description"
+      content="Ferienwohnung Antjes Ankerplatz in Cuxhaven - strandnah, mit Parkplatz, WLAN und direkter Buchungsanfrage online."
+    />
+    <meta name="robots" content="index,follow" />
+    <meta name="theme-color" content="#0e7490" />
+    <meta property="og:site_name" content="Antjes Ankerplatz" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Ferienwohnung Antjes Ankerplatz in Cuxhaven an der Nordsee" />
+    <meta
+      property="og:description"
+      content="Maritime Ferienwohnung in Cuxhaven: strandnah, mit Parkplatz, WLAN und direkter Buchungsanfrage online."
+    />
+    <meta property="og:image" content="/hero/cuxhaven-hero-1280.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <title>Ferienwohnung Antjes Ankerplatz in Cuxhaven</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "e2e:ui": "playwright test --ui",
     "e2e:install": "playwright install chromium",
     "e2e:report": "playwright show-report",
-    "build:frontend": "vite build",
+    "build:frontend": "node scripts/generate-seo-assets.mjs && vite build",
     "lint:functions": "npm --prefix functions run lint",
     "build:functions": "npm --prefix functions run build",
+    "seed:property": "node scripts/seedProperty.cjs",
     "lint": "npm run lint:frontend",
     "build": "npm run build:frontend",
     "ci": "npm run lint:frontend && npm run typecheck:frontend && npm run build:frontend && npm run lint:functions && npm run build:functions"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+
+Disallow: /admin
+Disallow: /admin/login
+Disallow: /login
+
+Sitemap: http://localhost:5173/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>http://localhost:5173/</loc>
+    <lastmod>2026-05-17</lastmod>
+  </url>
+  <url>
+    <loc>http://localhost:5173/gallery</loc>
+    <lastmod>2026-05-17</lastmod>
+  </url>
+  <url>
+    <loc>http://localhost:5173/prices</loc>
+    <lastmod>2026-05-17</lastmod>
+  </url>
+  <url>
+    <loc>http://localhost:5173/book</loc>
+    <lastmod>2026-05-17</lastmod>
+  </url>
+  <url>
+    <loc>http://localhost:5173/impressum</loc>
+    <lastmod>2026-05-17</lastmod>
+  </url>
+  <url>
+    <loc>http://localhost:5173/datenschutz</loc>
+    <lastmod>2026-05-17</lastmod>
+  </url>
+</urlset>

--- a/scripts/generate-seo-assets.mjs
+++ b/scripts/generate-seo-assets.mjs
@@ -1,0 +1,52 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const cwd = process.cwd();
+const publicDir = resolve(cwd, "public");
+const siteUrl = (
+  process.env.VITE_SITE_URL ||
+  process.env.SITE_URL ||
+  "http://localhost:5173"
+)
+  .trim()
+  .replace(/\/+$/, "");
+
+const publicRoutes = [
+  "/",
+  "/gallery",
+  "/prices",
+  "/book",
+  "/impressum",
+  "/datenschutz",
+];
+
+const today = new Date().toISOString().slice(0, 10);
+
+function urlFor(pathname) {
+  return `${siteUrl}${pathname === "/" ? "/" : pathname}`;
+}
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  publicRoutes
+    .map(
+      (pathname) =>
+        `  <url>\n` +
+        `    <loc>${urlFor(pathname)}</loc>\n` +
+        `    <lastmod>${today}</lastmod>\n` +
+        `  </url>`,
+    )
+    .join("\n") +
+  `\n</urlset>\n`;
+
+const robots = `User-agent: *\n` +
+  `Allow: /\n\n` +
+  `Disallow: /admin\n` +
+  `Disallow: /admin/login\n` +
+  `Disallow: /login\n\n` +
+  `Sitemap: ${siteUrl}/sitemap.xml\n`;
+
+mkdirSync(publicDir, { recursive: true });
+writeFileSync(resolve(publicDir, "sitemap.xml"), sitemap, "utf8");
+writeFileSync(resolve(publicDir, "robots.txt"), robots, "utf8");
+

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useLanguage } from "../i18n/useLanguage";
+
+const SITE_NAME = "Antjes Ankerplatz";
+
+type JsonLd = Record<string, unknown> | Array<Record<string, unknown>>;
+
+export type SeoProps = {
+  title: string;
+  description: string;
+  image?: string;
+  imageAlt?: string;
+  canonicalPath?: string;
+  noIndex?: boolean;
+  jsonLd?: JsonLd;
+};
+
+function getOrigin() {
+  const envBase = (import.meta.env.VITE_SITE_URL as string | undefined)?.trim();
+  if (envBase) {
+    return envBase.replace(/\/+$/, "");
+  }
+
+  if (typeof window !== "undefined" && window.location.origin) {
+    return window.location.origin.replace(/\/+$/, "");
+  }
+
+  return "";
+}
+
+function toAbsoluteUrl(path: string) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const origin = getOrigin();
+  if (!origin) {
+    return path;
+  }
+
+  return new URL(path.startsWith("/") ? path : `/${path}`, origin).toString();
+}
+
+function ensureMeta(id: string, attrs: Record<string, string>) {
+  const existing = document.getElementById(id) as HTMLMetaElement | null;
+  const el = existing ?? document.createElement("meta");
+
+  el.id = id;
+  Object.entries(attrs).forEach(([key, value]) => {
+    el.setAttribute(key, value);
+  });
+
+  if (!existing) {
+    document.head.appendChild(el);
+  }
+}
+
+function ensureLink(id: string, attrs: Record<string, string>) {
+  const existing = document.getElementById(id) as HTMLLinkElement | null;
+  const el = existing ?? document.createElement("link");
+
+  el.id = id;
+  Object.entries(attrs).forEach(([key, value]) => {
+    el.setAttribute(key, value);
+  });
+
+  if (!existing) {
+    document.head.appendChild(el);
+  }
+}
+
+function ensureScript(id: string, jsonLd: JsonLd | undefined) {
+  const existing = document.getElementById(id);
+
+  if (!jsonLd) {
+    existing?.remove();
+    return;
+  }
+
+  const el = (existing as HTMLScriptElement | null) ?? document.createElement("script");
+  el.id = id;
+  el.type = "application/ld+json";
+  el.textContent = JSON.stringify(jsonLd);
+
+  if (!existing) {
+    document.head.appendChild(el);
+  }
+}
+
+export function Seo({
+  title,
+  description,
+  image,
+  imageAlt,
+  canonicalPath,
+  noIndex = false,
+  jsonLd,
+}: SeoProps) {
+  const { pathname } = useLocation();
+  const { locale } = useLanguage();
+
+  useEffect(() => {
+    const canonicalUrl = toAbsoluteUrl(canonicalPath ?? pathname);
+    const ogImage = image ? toAbsoluteUrl(image) : "";
+    const robots = noIndex ? "noindex,nofollow" : "index,follow";
+    const ogLocale = locale === "de-DE" ? "de_DE" : "en_US";
+
+    document.title = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAME}`;
+
+    ensureMeta("seo-description", { name: "description", content: description });
+    ensureMeta("seo-robots", { name: "robots", content: robots });
+    ensureMeta("seo-og-title", { property: "og:title", content: title });
+    ensureMeta("seo-og-description", { property: "og:description", content: description });
+    ensureMeta("seo-og-type", { property: "og:type", content: "website" });
+    ensureMeta("seo-og-url", { property: "og:url", content: canonicalUrl });
+    ensureMeta("seo-og-site-name", { property: "og:site_name", content: SITE_NAME });
+    ensureMeta("seo-og-locale", { property: "og:locale", content: ogLocale });
+    ensureMeta("seo-twitter-card", {
+      name: "twitter:card",
+      content: ogImage ? "summary_large_image" : "summary",
+    });
+    ensureMeta("seo-twitter-title", { name: "twitter:title", content: title });
+    ensureMeta("seo-twitter-description", { name: "twitter:description", content: description });
+
+    if (ogImage) {
+      ensureMeta("seo-og-image", { property: "og:image", content: ogImage });
+      ensureMeta("seo-og-image-alt", {
+        property: "og:image:alt",
+        content: imageAlt ?? title,
+      });
+      ensureMeta("seo-twitter-image", { name: "twitter:image", content: ogImage });
+    } else {
+      document.getElementById("seo-og-image")?.remove();
+      document.getElementById("seo-og-image-alt")?.remove();
+      document.getElementById("seo-twitter-image")?.remove();
+    }
+
+    ensureLink("seo-canonical", {
+      rel: "canonical",
+      href: canonicalUrl,
+    });
+
+    ensureScript("seo-jsonld", jsonLd);
+  }, [canonicalPath, description, image, imageAlt, jsonLd, locale, noIndex, pathname, title]);
+
+  return null;
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -19,6 +19,29 @@ export const de: TranslationDictionary = {
   "app.footer.imprint": "Impressum",
   "app.footer.privacy": "Datenschutz",
 
+  "seo.homeTitle": "Ferienwohnung Antjes Ankerplatz in Cuxhaven an der Nordsee",
+  "seo.homeDescription":
+    "Maritime Ferienwohnung in Cuxhaven: strandnah, mit Parkplatz, WLAN und direkter Buchungsanfrage online.",
+  "seo.galleryTitle": "Bildergalerie der Ferienwohnung Antjes Ankerplatz",
+  "seo.galleryDescription":
+    "Entdecke Bilder von Wohnbereich, Schlafzimmer, Küche und Umgebung der Ferienwohnung.",
+  "seo.pricesTitle": ({ propertyName }: TranslationParams) =>
+    `${propertyName} - Preise und Saisonübersicht`,
+  "seo.pricesDescription":
+    "Transparente Nachtpreise, Endreinigung und Saisonübersicht für deine Ferienwohnung in Cuxhaven.",
+  "seo.bookingTitle": "Buchung anfragen für Antjes Ankerplatz in Cuxhaven",
+  "seo.bookingDescription":
+    "Prüfe die Verfügbarkeit und sende deine Buchungsanfrage für den gewünschten Zeitraum direkt online.",
+  "seo.imprintTitle": "Impressum | Antjes Ankerplatz",
+  "seo.imprintDescription":
+    "Kontakt, Anschrift und rechtliche Angaben zur Ferienwohnung Antjes Ankerplatz.",
+  "seo.privacyTitle": "Datenschutzerklärung | Antjes Ankerplatz",
+  "seo.privacyDescription":
+    "Informationen zur Verarbeitung personenbezogener Daten, Cookies und Kontaktanfragen.",
+  "seo.loginTitle": "Anmeldung | Antjes Ankerplatz",
+  "seo.loginDescription":
+    "Zugang für den geschützten Verwaltungsbereich der Ferienwohnung.",
+
   "cookie.title": "Cookie-Einstellungen",
   "cookie.description":
     "Wir nutzen notwendige Cookies und bieten dir optionale Kategorien für Statistik und Marketing an.",
@@ -215,6 +238,29 @@ export const en: TranslationDictionary = {
   "app.footer.bookNow": "Book now",
   "app.footer.imprint": "Legal notice",
   "app.footer.privacy": "Privacy",
+
+  "seo.homeTitle": "Antjes Ankerplatz holiday apartment in Cuxhaven by the North Sea",
+  "seo.homeDescription":
+    "Maritime holiday apartment in Cuxhaven: near the beach, with parking, Wi-Fi and direct online booking inquiry.",
+  "seo.galleryTitle": "Photo gallery of Antjes Ankerplatz",
+  "seo.galleryDescription":
+    "Explore photos of the living area, bedrooms, kitchen, and surroundings of the apartment.",
+  "seo.pricesTitle": ({ propertyName }: TranslationParams) =>
+    `${propertyName} - prices and seasonal overview`,
+  "seo.pricesDescription":
+    "Transparent nightly rates, cleaning fee, and seasonal overview for your holiday apartment in Cuxhaven.",
+  "seo.bookingTitle": "Request a booking for Antjes Ankerplatz in Cuxhaven",
+  "seo.bookingDescription":
+    "Check availability and send your booking request for the desired period directly online.",
+  "seo.imprintTitle": "Legal notice | Antjes Ankerplatz",
+  "seo.imprintDescription":
+    "Contact details, address, and legal information for Antjes Ankerplatz.",
+  "seo.privacyTitle": "Privacy policy | Antjes Ankerplatz",
+  "seo.privacyDescription":
+    "Information about personal data, cookies, and contact requests.",
+  "seo.loginTitle": "Sign in | Antjes Ankerplatz",
+  "seo.loginDescription":
+    "Access for the protected administration area of the holiday apartment.",
   "cookie.title": "Cookie settings",
   "cookie.description":
     "We use essential cookies and offer optional categories for statistics and marketing.",

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -8,6 +8,8 @@ import { getFirstProperty } from "../lib/db";
 import BookingsTable from "../components/admin/BookingsTable";
 import { cancelBooking } from "../lib/db";
 import OccupancyCalendar from "../components/admin/OccupancyCalendar";
+import { Seo } from "../components/Seo";
+import { useT } from "../i18n/useLanguage";
 
 type TabKey = "property" | "seasons" | "taxes" | "bookings" | "calendar";
 
@@ -28,6 +30,7 @@ function panelId(key: TabKey): string {
 }
 
 export default function AdminDashboard() {
+  const t = useT();
   const [tab, setTab] = useState<TabKey>("property");
   const [propertyId, setPropertyId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -79,6 +82,13 @@ export default function AdminDashboard() {
 
   return (
     <section className="space-y-6">
+      <Seo
+        title="Admin"
+        description={t("seo.loginDescription")}
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt={t("home.heroAlt")}
+        noIndex
+      />
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Admin</h1>
         <button

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -17,6 +17,7 @@ import {
   loadUnavailableDates,
   sendBookingRequestMail,
 } from "./booking/services";
+import { Seo } from "../components/Seo";
 
 const MIN_NIGHTS = 2;
 
@@ -314,6 +315,12 @@ export default function Booking() {
 
   return (
     <section className="space-y-6">
+      <Seo
+        title={t("seo.bookingTitle")}
+        description={t("seo.bookingDescription")}
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt={t("home.heroAlt")}
+      />
       <header className="text-center">
         <h1 className="text-3xl font-semibold tracking-tight">
           {t("booking.heading", { propertyName })}

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -5,9 +5,12 @@ import {
   GALLERY_IMAGES,
 } from "../lib/galleryImages";
 import { useT } from "../i18n/useLanguage";
+import { Seo } from "../components/Seo";
 
 export default function Gallery() {
   const t = useT();
+  const galleryTitle = t("seo.galleryTitle");
+  const galleryDescription = t("seo.galleryDescription");
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const lightboxTitleId = useId();
@@ -52,6 +55,12 @@ export default function Gallery() {
 
   return (
     <section className="mx-auto max-w-6xl">
+      <Seo
+        title={galleryTitle}
+        description={galleryDescription}
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt={t("home.heroAlt")}
+      />
       <div className="mb-5">
         <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">
           {t("gallery.title")}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,65 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   buildGallerySrcSet,
   buildGalleryVariantPath,
   GALLERY_IMAGES,
 } from "../lib/galleryImages";
 import { useT } from "../i18n/useLanguage";
+import { Seo } from "../components/Seo";
 
 const SLIDESHOW_INTERVAL_MS = 9000;
 const SLIDESHOW_TRANSITION_MS = 3200;
 
 export default function Home() {
   const t = useT();
+  const homeDescription = t("seo.homeDescription");
+  const homeTitle = t("seo.homeTitle");
+  const homeJsonLd = useMemo(
+    () => ({
+      "@context": "https://schema.org",
+      "@type": "VacationRental",
+      name: "Antjes Ankerplatz",
+      description: homeDescription,
+      url: "/",
+      image: [
+        "/hero/cuxhaven-hero-640.jpg",
+        "/hero/cuxhaven-hero-960.jpg",
+        "/hero/cuxhaven-hero-1280.jpg",
+      ],
+      address: {
+        "@type": "PostalAddress",
+        streetAddress: "Spangerstr. 9",
+        postalCode: "27476",
+        addressLocality: "Cuxhaven",
+        addressCountry: "DE",
+      },
+      telephone: "+49 4721 21508",
+      email: "mutzi@antjes-ankerplatz.net",
+      amenityFeature: [
+        {
+          "@type": "LocationFeatureSpecification",
+          name: "Strandnah",
+          value: true,
+        },
+        {
+          "@type": "LocationFeatureSpecification",
+          name: "Kostenloses Parken",
+          value: true,
+        },
+        {
+          "@type": "LocationFeatureSpecification",
+          name: "Haustiere erlaubt",
+          value: true,
+        },
+        {
+          "@type": "LocationFeatureSpecification",
+          name: "WLAN & Smart-TV",
+          value: true,
+        },
+      ],
+    }),
+    [homeDescription],
+  );
   const totalSlides = GALLERY_IMAGES.length;
   const [activeSlide, setActiveSlide] = useState(0);
   const [isSliding, setIsSliding] = useState(false);
@@ -47,6 +96,13 @@ export default function Home() {
 
   return (
     <section className="relative w-full">
+      <Seo
+        title={homeTitle}
+        description={homeDescription}
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt={t("home.heroAlt")}
+        jsonLd={homeJsonLd}
+      />
       <div className="relative h-[52vh] w-full overflow-hidden rounded-[14px] md:h-[64vh]">
         <picture>
           <source

--- a/src/pages/Imprint.tsx
+++ b/src/pages/Imprint.tsx
@@ -1,6 +1,14 @@
+import { Seo } from "../components/Seo";
+
 export default function Imprint() {
   return (
     <section className="max-w-3xl mx-auto p-6 prose">
+      <Seo
+        title="Impressum"
+        description="Kontakt, Anschrift und rechtliche Angaben zur Ferienwohnung Antjes Ankerplatz."
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt="Meerblick"
+      />
       <h1 className="text-2xl font-bold mb-6">Impressum</h1>
       <address className="not-italic mb-4">
         <p className="mb-4"><strong>Antja & Siebo Remmers</strong></p>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../app/providers/AuthProvider';
 import { auth } from '../lib/firebaseAuth';
 import { useT } from '../i18n/useLanguage';
+import { Seo } from '../components/Seo';
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
@@ -75,6 +76,13 @@ export default function Login() {
   if (user) {
     return (
       <section className="space-y-4">
+        <Seo
+          title={t("login.adminTitle")}
+          description={t("seo.loginDescription")}
+          image="/hero/cuxhaven-hero-1280.jpg"
+          imageAlt={t("home.heroAlt")}
+          noIndex
+        />
         <h1 className="text-xl font-semibold">{t("login.adminTitle")}</h1>
         <p>{t("login.loggedInAs", { email: user.email ?? "" })}</p>
         <button onClick={doLogout} className="rounded bg-gray-800 px-3 py-2 text-white">{t("login.logout")}</button>
@@ -84,6 +92,13 @@ export default function Login() {
 
   return (
     <section className="mx-auto max-w-md space-y-6">
+      <Seo
+        title={mode === 'login' ? t("seo.loginTitle") : t("login.titleRegister")}
+        description={t("seo.loginDescription")}
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt={t("home.heroAlt")}
+        noIndex
+      />
       <h1 className="text-xl font-semibold">{mode === 'login' ? t("login.titleLogin") : t("login.titleRegister")}</h1>
 
       <form onSubmit={mode === 'login' ? doLogin : doRegister} className="space-y-3">

--- a/src/pages/Prices.tsx
+++ b/src/pages/Prices.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getFirstPropertyLite, getPropertyLite, listSeasonsLite } from "../lib/publicPricingData";
 import { useLanguage, useT } from "../i18n/useLanguage";
+import { Seo } from "../components/Seo";
 
 type Row = {
   id: string;
@@ -95,6 +96,12 @@ export default function Prices() {
 
   return (
     <section className="space-y-8">
+      <Seo
+        title={t("seo.pricesTitle", { propertyName })}
+        description={t("seo.pricesDescription")}
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt={t("home.heroAlt")}
+      />
       <header className="text-center">
         <h1 className="text-3xl font-semibold tracking-tight">{t("prices.title", { propertyName })}</h1>
         <p className="mt-2 text-slate-600">

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,6 +1,14 @@
+import { Seo } from "../components/Seo";
+
 export default function Privacy() {
   return (
     <div className="max-w-3xl mx-auto p-6 prose">
+      <Seo
+        title="Datenschutzerklärung"
+        description="Informationen zur Verarbeitung personenbezogener Daten, Cookies und Kontaktanfragen."
+        image="/hero/cuxhaven-hero-1280.jpg"
+        imageAlt="Meerblick"
+      />
       <h1 className="text-2xl font-bold mb-4">Datenschutzerklärung</h1>
       <p className="mb-4">
         Der Schutz Ihrer persönlichen Daten ist uns wichtig. Diese Website verarbeitet personenbezogene Daten


### PR DESCRIPTION
## What changed
- Added a reusable SEO helper that manages page titles, descriptions, canonical URLs, Open Graph, Twitter cards, and `noindex` for protected areas.
- Added route-specific metadata for the public pages and structured data for the home page.
- Added build-time generation for `robots.txt` and `sitemap.xml` using `VITE_SITE_URL`.
- Updated the base HTML defaults and documentation for the new SEO environment variable.

## Why
The site needed stronger on-page SEO signals and better crawler discovery for public content, while keeping admin and login routes out of search indexing.

## Validation
- `npm run lint:frontend`
- `npm run build:frontend`

## Notes
- `VITE_SITE_URL` should be set in production so canonical URLs and the sitemap point at the real domain.